### PR TITLE
Add mobile navigation

### DIFF
--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -1,7 +1,14 @@
 <script lang="ts">
+  import { stores } from '@sapper/app';
+
   export let segment: string;
 
   let showMobileMenu = false;
+  const { page } = stores();
+
+  page.subscribe(() => {
+    showMobileMenu = false;
+  })
 </script>
 
 <nav class="row-center">

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   export let segment: string;
+
+  let showMobileMenu = false;
 </script>
 
 <nav class="row-center">
@@ -7,7 +9,8 @@
     <a class="row-center" sapper:prefetch href="."
       ><img src="/logo.svg" alt="Hack4Impact logo" /></a
     >
-    <div class="row-center" id="navlinks">
+    <button on:click={() => showMobileMenu = !showMobileMenu} class="hide-on-desktop">{showMobileMenu ? '×' : '≡'}</button>
+    <div class="row-center" class:closedOnMobile={!showMobileMenu} id="navlinks">
       <a
         class="navlink"
         sapper:prefetch
@@ -45,7 +48,6 @@
 <style>
   nav {
     font-weight: 300;
-
     box-shadow: 0 0 4px 0 rgba(0, 0, 0, 0.12);
     position: sticky;
     top: 0;
@@ -107,5 +109,56 @@
   .navlink:not([aria-current]):hover::before {
     opacity: 100%;
     transition: 0.2s;
+  }
+
+  .hide-on-desktop {
+    display: none;
+  }
+
+  button.hide-on-desktop {
+    background: none;
+    border: none;
+    font-size: 24px;
+    transform: scaleX(1.1);
+  }
+
+  @media only screen and (max-width: 792px) {
+    
+    /* utility */
+
+    .hide-on-desktop {
+      display: block;
+    }
+
+    .closedOnMobile {
+      display: none;
+    }
+
+    /* modified */
+
+    nav {
+      height: 4em;
+    }
+    #navlinks {
+      position: fixed;
+      flex-direction: column;
+      align-items: stretch;
+      top: 4em;
+      background-color: white;
+      width: 100%;
+      left: 0;
+      box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.12);
+    }
+
+    .navlink {
+      display: block;
+    }
+
+    .navlink:not([aria-current])::before {
+      opacity: 100%;
+      height: 1px;
+      background-color: var(--gray-lighter);
+    }
+
   }
 </style>

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-  import { stores } from '@sapper/app';
-
   export let segment: string;
+  let oldSegment;
 
   let showMobileMenu = false;
-  const { page } = stores();
 
-  page.subscribe(() => {
-    showMobileMenu = false;
-  })
+  $: {
+    if (segment !== oldSegment) {
+      showMobileMenu = false;
+    }
+  }
 </script>
 
 <nav class="row-center">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "lib": ["DOM", "ES2017"]
+    "lib": ["DOM", "ES2017"],
+    "types": ["svelte", "@sapper"]
   },
   "include": ["src/**/*", "src/node_modules/**/*"],
   "exclude": ["node_modules/*", "__sapper__/*", "static/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "@tsconfig/svelte/tsconfig.json",
   "compilerOptions": {
-    "lib": ["DOM", "ES2017"],
-    "types": ["svelte", "@sapper"]
+    "lib": ["DOM", "ES2017"]
   },
   "include": ["src/**/*", "src/node_modules/**/*"],
   "exclude": ["node_modules/*", "__sapper__/*", "static/*"]


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready

## Description

Adds toggle-able mobile navigation for screens smaller than 792px.

## Screenshots

<img width="520" alt="Screen Shot 2021-04-17 at 10 08 50 PM" src="https://user-images.githubusercontent.com/19193347/115132866-957a5f80-9fc9-11eb-9aa5-2be2fe6f6442.png">
