### PR TITLE
Fix banner info, image overlap

### DIFF
--- a/src/components/projects/FeaturedBanner.svelte
+++ b/src/components/projects/FeaturedBanner.svelte
@@ -95,6 +95,10 @@
     .meta.masked {
       background: rgba(0, 0, 0, 0.3);
     }
+
+    figure {
+      max-width: 100%;
+    }
   }
 
   @media only screen and (max-width: 1105px) {

--- a/src/components/projects/FeaturedBanner.svelte
+++ b/src/components/projects/FeaturedBanner.svelte
@@ -62,6 +62,7 @@
     right: 0;
     top: 0;
     height: 100%;
+    max-width: 25%;
   }
 
   figure img {
@@ -78,6 +79,12 @@
     overflow: hidden;
     box-sizing: border-box;
     width: 100%;
+  }
+
+  @media only screen and (min-width: 1500px) {
+    h2 {
+      font-size: calc(0.9 * 1.6rem);
+    }
   }
 
   @media only screen and (max-width: 1350px) {


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready

## Description

- Fix overlap by setting max banner image to 25%
- Keep banner title scale on larger screens

## Screenshots
![Screen Shot 2021-07-10 at 1 03 58 AM](https://user-images.githubusercontent.com/19193347/125152470-c1196b80-e11a-11eb-8208-073387602f4b.png)

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
