### PR TITLE
Prevent duplicate project features

### DIFF
--- a/src/utils/projects.ts
+++ b/src/utils/projects.ts
@@ -10,51 +10,79 @@ interface ProjectsInfo {
   semesters: string[];
 }
 
+// Function copied from https://stackoverflow.com/a/12646864
+function shuffleArray<T>(array: T[]): void {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+}
+
 export function generateProjectsInfo(projects: Project[]): ProjectsInfo {
-  const projectArrayMap: Record<string, Project[]> = {};
-  const projectMap: Record<string, SemesterProjects> = {};
-  const semesters: string[] = [];
+  // loop until valid configuration (no project is featured more than once) is generated
+  while (true) {
+    shuffleArray(projects);
 
-  projects.forEach((project) =>
-    project.semester.forEach((semester) => {
-      if (projectArrayMap[semester] !== undefined) {
-        projectArrayMap[semester].push(project);
-      } else {
-        projectArrayMap[semester] = [project];
-        semesters.push(semester);
+    const projectArrayMap: Record<string, Project[]> = {};
+    const projectMap: Record<string, SemesterProjects> = {};
+    const semesters: string[] = [];
+
+    const featuredSlugs = new Set<string>();
+    let numFeatured = 0;
+
+    projects.forEach((project) =>
+      project.semester.forEach((semester) => {
+        if (projectArrayMap[semester] !== undefined) {
+          projectArrayMap[semester].push(project);
+        } else {
+          projectArrayMap[semester] = [project];
+          semesters.push(semester);
+        }
+      })
+    );
+
+    semesters.forEach((semester) => {
+      const projects = projectArrayMap[semester];
+      const featuredProjects = projects.filter((project) => project.featured);
+
+      const featured: Project | undefined =
+        featuredProjects.length > 0
+          ? featuredProjects[
+              Math.floor(Math.random() * featuredProjects.length)
+            ]
+          : undefined;
+
+      if (featured !== undefined) {
+        numFeatured += 1;
+        featuredSlugs.add(featured.slug);
       }
-    })
-  );
 
-  semesters.forEach((semester) => {
-    const projects = projectArrayMap[semester];
-    const featuredProjects = projects.filter((project) => project.featured);
+      projectMap[semester] = {
+        featured,
+        projects: projects.filter((project) => project !== featured),
+      };
+    });
 
-    const featured: Project | undefined =
-      featuredProjects.length > 0
-        ? featuredProjects[Math.floor(Math.random() * featuredProjects.length)]
-        : undefined;
-
-    projectMap[semester] = {
-      featured,
-      projects: projects.filter((project) => project !== featured),
-    };
-  });
-
-  semesters.sort((a, b) => {
-    const semA = parseSemester(a);
-    const semB = parseSemester(b);
-
-    if (semA.year === semB.year) {
-      if (semA.season === semB.season) {
-        return 0;
-      }
-
-      return semB.season < semA.season ? 1 : -1;
+    // if one project is featured in multiple semesters, the following numbers will differ
+    if (featuredSlugs.size < numFeatured) {
+      continue;
     }
 
-    return semB.year - semA.year;
-  });
+    semesters.sort((a, b) => {
+      const semA = parseSemester(a);
+      const semB = parseSemester(b);
 
-  return { projectMap, semesters };
+      if (semA.year === semB.year) {
+        if (semA.season === semB.season) {
+          return 0;
+        }
+
+        return semB.season < semA.season ? 1 : -1;
+      }
+
+      return semB.year - semA.year;
+    });
+
+    return { projectMap, semesters };
+  }
 }


### PR DESCRIPTION
The previous project map generation algorithm did not consider if a project could be featured multiple times, and as such featured projects over multiple semesters could be shown in the featured banner multiple times in `/projects`. This PR loops over the project map generation until a valid configuration (one where no project is featured for multiple semesters) is generated.