### PR TITLE
Fix footer semester scrolling behavior

### DIFF
--- a/src/components/Footer.svelte
+++ b/src/components/Footer.svelte
@@ -8,40 +8,45 @@
   <div id="footer-contents">
     <div id="inquiries">
       <div id="logo-container">
-        <a sveltekit:prefetch href="/"
-          ><img src="/logo.svg" alt="Hack4Impact logo" /></a
-        >
+        <a sveltekit:prefetch href="/">
+          <img src="/logo.svg" alt="Hack4Impact logo" />
+        </a>
       </div>
 
       For all inquiries of partnership or sponsorship, please contact us at
-      <a class="blue-text" href="mailto:uiuc@hack4impact.org"
-        >uiuc@hack4impact.org</a
-      >
+      <a class="blue-text" href="mailto:uiuc@hack4impact.org">
+        uiuc@hack4impact.org
+      </a>
     </div>
     <div class="links">
       <span>
         <ul>
           <li class="blue-text link-section-header">Connect With Us</li>
           <li>
-            <a href="https://www.facebook.com/h4iuiuc" rel="external"
-              >Facebook</a
-            >
+            <a href="https://www.facebook.com/h4iuiuc" rel="external">
+              Facebook
+            </a>
           </li>
           <li>
-            <a href="https://github.com/hack4impact-uiuc" rel="external"
-              >GitHub</a
-            >
+            <a href="https://github.com/hack4impact-uiuc" rel="external">
+              GitHub
+            </a>
           </li>
-
           <li>
-            <a href="https://www.instagram.com/hack4impactuiuc/" rel="external"
-              >Instagram</a
-            >
+            <a href="https://www.instagram.com/hack4impactuiuc/" rel="external">
+              Instagram
+            </a>
           </li>
         </ul>
         <ul>
           <li>
-            <a class="blue-text link-section-header" href="/about">About Us</a>
+            <a
+              class="blue-text link-section-header"
+              href="/about"
+              sveltekit:prefetch
+            >
+              About Us
+            </a>
           </li>
           <li><a href="/about/work" sveltekit:prefetch>How We Work</a></li>
           <li><a href="/about/team" sveltekit:prefetch>Meet The Team</a></li>
@@ -56,13 +61,13 @@
               sveltekit:prefetch>Projects</a
             >
           </li>
-          {#each semesters.slice(0, 3) as semester}<li>
-              <a
-                href="/projects/#{semesterToId(semester)}"
-                sveltekit:noscroll
-                sveltekit:prefetch>{semester}</a
-              >
-            </li>{/each}
+          {#each semesters.slice(0, 3) as semester}
+            <li>
+              <a href="/projects#{semesterToId(semester)}" sveltekit:prefetch>
+                {semester}
+              </a>
+            </li>
+          {/each}
         </ul>
         <ul>
           <li>

--- a/src/routes/projects/index.svelte
+++ b/src/routes/projects/index.svelte
@@ -18,7 +18,6 @@
 </script>
 
 <script lang="ts">
-
   export let projectMap: Record<string, SemesterProjects>;
   export let semesters: string[];
 

--- a/src/routes/projects/index.svelte
+++ b/src/routes/projects/index.svelte
@@ -77,9 +77,7 @@
           <li id="{`semester-${idx}`}">
             <a
               href="{`/projects#${semesterToId(semester)}`}"
-              on:click="{() => {
-                setSemester(idx);
-              }}"
+              on:click="{() => setSemester(idx)}"
               class:active="{currentSemester === idx}"
             >
               {semester}

--- a/src/routes/projects/index.svelte
+++ b/src/routes/projects/index.svelte
@@ -94,11 +94,7 @@
           {#if projectMap[semester].featured !== undefined}
             <FeaturedBanner project="{projectMap[semester].featured}" />
           {/if}
-          <span
-            use:viewport
-            on:enterViewport="{() => 
-              setSemester(idx)
-            }"></span>
+          <span use:viewport on:enterViewport="{() => setSemester(idx)}"></span>
           <div class="project-grid">
             {#each projectMap[semester].projects as project}
               <ProjectCard project="{project}" />

--- a/src/routes/projects/index.svelte
+++ b/src/routes/projects/index.svelte
@@ -96,9 +96,9 @@
           {/if}
           <span
             use:viewport
-            on:enterViewport="{() => {
-              setSemester(idx);
-            }}"></span>
+            on:enterViewport="{() => 
+              setSemester(idx)
+            }"></span>
           <div class="project-grid">
             {#each projectMap[semester].projects as project}
               <ProjectCard project="{project}" />

--- a/src/routes/projects/index.svelte
+++ b/src/routes/projects/index.svelte
@@ -18,24 +18,9 @@
 </script>
 
 <script lang="ts">
-  import { onMount } from "svelte";
 
   export let projectMap: Record<string, SemesterProjects>;
   export let semesters: string[];
-
-  onMount(() => {
-    const {
-      location: { hash: url },
-    } = window;
-    const sectionId = url.split("#").pop();
-
-    if (sectionId) {
-      const sectionDOM = document.getElementById(sectionId);
-      if (sectionDOM) {
-        sectionDOM.scrollIntoView(true);
-      }
-    }
-  });
 
   let windowWidth: number | undefined;
 
@@ -92,7 +77,7 @@
         {#each semesters as semester, idx}
           <li id="{`semester-${idx}`}">
             <a
-              href="{`/projects/#${semesterToId(semester)}`}"
+              href="{`/projects#${semesterToId(semester)}`}"
               on:click="{() => {
                 setSemester(idx);
               }}"
@@ -112,7 +97,11 @@
           {#if projectMap[semester].featured !== undefined}
             <FeaturedBanner project="{projectMap[semester].featured}" />
           {/if}
-          <span use:viewport on:enterViewport="{() => setSemester(idx)}"></span>
+          <span
+            use:viewport
+            on:enterViewport="{() => {
+              setSemester(idx);
+            }}"></span>
           <div class="project-grid">
             {#each projectMap[semester].projects as project}
               <ProjectCard project="{project}" />


### PR DESCRIPTION
For the `n`th time, this PR fixes scrolling behavior when clicking on a project semester link (e.g. `/projects#spring-2021`) from the footer. These changes are likely necessary due to differences in how SvelteKit handles routes as opposed to Sapper.