### PR TITLE
Show White Logos for projects if available

### DIFF
--- a/src/routes/projects/[slug].svelte
+++ b/src/routes/projects/[slug].svelte
@@ -14,6 +14,11 @@
 
     const project: Project = await res.json();
 
+    // default to colored logo if white logo unavailable
+    if (!project.logoWhite) {
+      project.logoWhite = project.nonprofitLogo;
+    }
+
     return { props: { project } };
   }
 </script>
@@ -57,8 +62,8 @@
   <span slot="left">
     <img
       id="nonprofit-logo"
-      src="{setImageHeight(project.nonprofitLogo.src, 100)}"
-      alt="{project.nonprofitLogo.alt}"
+      src="{setImageHeight(project.logoWhite.src, 100)}"
+      alt="{project.logoWhite.alt}"
     />
     <h1>{project.name}</h1>
     <h2 id="project-summary">{project.summary}</h2></span
@@ -146,7 +151,6 @@
   #nonprofit-logo {
     height: 60px;
     margin-bottom: 20px;
-    background-color: #fff;
   }
 
   #team-content {

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -37,6 +37,7 @@ export interface Project {
   nonprofitDescription: string; // TODO: is this html?
   nonprofitUrl: string;
   nonprofitLogo: Image;
+  logoWhite?: Image;
   accentColor: string;
   fullDescription: string;
   productManager: Member[];


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready

## Description

Shows white version of logos on colored header when available, otherwise defaults to showing regular logo

## Screenshots

<img width="1528" alt="Screen Shot 2021-09-14 at 5 16 32 PM" src="https://user-images.githubusercontent.com/19193347/133341191-9cb76645-391e-401e-840d-1ce05b19d541.png">

