### PR TITLE
Fix member card aspect ratio on Safari

### DIFF
--- a/src/components/projects/Member.svelte
+++ b/src/components/projects/Member.svelte
@@ -19,6 +19,7 @@
   .member {
     color: #fff;
     padding: 10%;
+    box-sizing: border-box;
   }
 
   img {


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready

## Description

Fixed box sizing issue on Safari causing images to be stretched