### PR TITLE
Add member image script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "description": "Hack4Impact UIUC's chapter website.",
   "version": "0.0.1",
   "scripts": {
-    "build": "svelte-kit build && npm run minify",
+    "build": "svelte-kit build && npm run minify && npm run build:images",
+    "build:images": "node scripts/loadMemberImages",
     "check": "svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-check --tsconfig ./tsconfig.json --watch",
     "dev": "svelte-kit dev",

--- a/scripts/loadMemberImages.js
+++ b/scripts/loadMemberImages.js
@@ -1,0 +1,32 @@
+import { readFileSync } from "fs";
+import { promisify } from "util";
+import { exec } from "child_process";
+
+const execPromise = promisify(exec);
+
+async function run() {
+  await execPromise("mkdir -p build/members");
+
+  const fileContents = readFileSync("build/server/members.json");
+  const members = JSON.parse(fileContents.toString());
+  const allMembers = members.active.concat(members.alumni);
+
+  await Promise.all(allMembers.map(loadMemberImage));
+}
+
+async function loadMemberImage(member) {
+  const url = `${member.picture.src}?h=1000&fmt=jpg`.replace("////", "//");
+  const nameSnakeCase = member.name
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase()
+    .replace(/ /g, "_")
+    .replace(/-/g, "");
+
+  const filePath = `build/members/${nameSnakeCase}.jpg`;
+
+  await promisify(exec)(`curl -o ${filePath} ${url}`);
+  console.log(`Loaded ${filePath}`);
+}
+
+run();

--- a/scripts/loadMemberImages.js
+++ b/scripts/loadMemberImages.js
@@ -1,13 +1,14 @@
-import { readFileSync } from "fs";
+import { readFile } from "fs";
 import { promisify } from "util";
 import { exec } from "child_process";
 
 const execPromise = promisify(exec);
+const readFilePromise = promisify(readFile);
 
 async function run() {
   await execPromise("mkdir -p build/members");
 
-  const fileContents = readFileSync("build/server/members.json");
+  const fileContents = await readFilePromise("build/server/members.json");
   const members = JSON.parse(fileContents.toString());
   const allMembers = members.active.concat(members.alumni);
 
@@ -25,7 +26,7 @@ async function loadMemberImage(member) {
 
   const filePath = `build/members/${nameSnakeCase}.jpg`;
 
-  await promisify(exec)(`curl -o ${filePath} ${url}`);
+  await execPromise(`curl -o ${filePath} ${url}`);
   console.log(`Loaded ${filePath}`);
 }
 


### PR DESCRIPTION
Adds a build-time script that loads static member images into the output directory's `members` subdirectory for easy access. Names are converted to simple snake_case unicode (no accents, etc.), with spaces converted to underscores and dashes removed.

Example: https://615501c2bbbfb90007e186a5--h4iuiuc.netlify.app/members/arpan_laha.jpg