### PR TITLE
Close mobile menu on navigation end

### DIFF
--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -1,17 +1,10 @@
 <script lang="ts">
   export let path: string | undefined;
-  // let oldSegment: string;
-
-  let showMobileMenu = false;
-
-  // $: {
-  //   if (segment !== oldSegment || (path && !path.startsWith(segment))) {
-  //     showMobileMenu = false;
-  //   }
-  // }
 
   const dropdownRoutes = ["Nonprofits", "Sponsors", "Students"];
+
   let windowWidth: number | undefined;
+  let showMobileMenu = false;
 </script>
 
 <svelte:window
@@ -63,7 +56,6 @@
           {#each dropdownRoutes as route}
             <a
               sveltekit:prefetch
-              on:click={() => (showMobileMenu = false)}
               aria-current={path && path.includes(`join/${route.toLowerCase()}`)
                 ? "page"
                 : undefined}

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -14,7 +14,10 @@
   let windowWidth: number | undefined;
 </script>
 
-<svelte:window bind:innerWidth={windowWidth} />
+<svelte:window
+  bind:innerWidth={windowWidth}
+  on:sveltekit:navigation-end={() => (showMobileMenu = false)}
+/>
 
 <nav class="row-center">
   <div class="row-center" id="nav-contents">


### PR DESCRIPTION
## Status:
:rocket:
## Description
Closes the mobile menu on any navigation changes. I went for a more global solution since it more closely resembles the functionality of MPAs. If desired, I can alter the code to only close the mobile navigation when _nav menu_ links are clicked, but I do think that closing the menu on all navigation changes is more familiar to the user.

Fixes: #47 

## Videos

https://user-images.githubusercontent.com/23221268/144532184-0e57ca72-3825-41c2-bf47-a39907458ece.mov

