### PR TITLE
Center Member Name on Projects Page

### DIFF
--- a/src/components/projects/Member.svelte
+++ b/src/components/projects/Member.svelte
@@ -20,6 +20,7 @@
     color: #fff;
     padding: 10%;
     box-sizing: border-box;
+    text-align: center;
   }
 
   img {


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: 🚀 

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Currently, members with names which overflow to two lines appear left-aligned. Centering the names to make it look a little more tidy :) 


## Todos
 Didn't test locally, just used chrome dev-tools so maybe want to check if it collides with anything else.

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
Before:
![before](https://user-images.githubusercontent.com/3940879/147540677-1a7bdaef-2ec2-4721-8d8c-0a47006965c4.png)

After:

![after](https://user-images.githubusercontent.com/3940879/147540690-b48a0755-2795-4c3f-a007-ec1ef8bcfa9b.png)