### PR TITLE
Don't use load parameter path to avoid reloading

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="@sveltejs/kit" />

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-  export let path: string | undefined;
+  import { page } from "$app/stores";
 
   const dropdownRoutes = ["Nonprofits", "Sponsors", "Students"];
 
   let windowWidth: number | undefined;
   let showMobileMenu = false;
+
+  $: path = $page.path;
 </script>
 
 <svelte:window

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -2,14 +2,12 @@
   import Nav from "$lib/components/Nav.svelte";
   import Footer from "$lib/components/Footer.svelte";
 
-  export async function load({ page, fetch }) {
+  export async function load({ fetch }) {
     const res = await fetch("/server/project-semesters.json");
 
     const semesters: string[] = await res.json();
 
-    const { path } = page;
-
-    return { props: { semesters, path } };
+    return { props: { semesters } };
   }
 </script>
 
@@ -18,7 +16,6 @@
   import { beforeUpdate } from "svelte";
 
   export let semesters: string[] = [];
-  export let path: string;
 
   beforeUpdate(() =>
     ackeeTracker
@@ -27,7 +24,7 @@
   );
 </script>
 
-<Nav {path} />
+<Nav />
 
 <main>
   <slot />


### PR DESCRIPTION
## Status:

:rocket: Ready

## Description

Fixes: #56 

I also added the `app.d.ts` file. I'm not sure why that wasn't there before. Should I not add it?

## Screenshots
For some reason the layout is still loaded on the *first* navigation, but none of the subsequent ones. I'll look into this, but for now this is better than it was before.

https://user-images.githubusercontent.com/23221268/159059525-7f44a934-8131-4c8a-aef0-237eac772157.mov


