### PR TITLE
Fix slashes on certain html elements

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -72,10 +72,10 @@ export class ContentWrapper {
                       node.data.target.fields;
                     return `
                       <div class="column-center long-form-embed">
-                          <img src="https:${file.url}?w=1200" alt="${title}" \\>
+                          <img src="https:${file.url}?w=1200" alt="${title}" />
                           ${
                             description !== undefined
-                              ? `<span>${description}<\\span>`
+                              ? `<span>${description}</span>`
                               : ""
                           }
                       </div>


### PR DESCRIPTION
## Status:
:rocket: Ready
## Description

Fixes current build failure

Is there a reason these were backslashes before?