### PR TITLE
Update sponsors page

### DIFF
--- a/src/components/Icon.svelte
+++ b/src/components/Icon.svelte
@@ -1,8 +1,10 @@
 <script context="module" lang="ts">
+  import Book from "@svicons/boxicons-solid/book.svelte";
   import Brain from "@svicons/boxicons-regular/brain.svelte";
   import Bulb from "@svicons/boxicons-solid/bulb.svelte";
   import Calendar from "@svicons/boxicons-solid/calendar.svelte";
   import Code from "@svicons/boxicons-regular/code-alt.svelte";
+  import Chalkboard from "@svicons/boxicons-solid/chalkboard.svelte";
   import Conversation from "@svicons/boxicons-solid/conversation.svelte";
   import Devices from "@svicons/boxicons-solid/devices.svelte";
   import Edit from "@svicons/boxicons-regular/edit.svelte";
@@ -14,6 +16,7 @@
   import Vector from "@svicons/boxicons-solid/vector.svelte";
   import Health from "@svicons/boxicons-regular/health.svelte";
   import Graduation from "@svicons/boxicons-solid/graduation.svelte";
+  import Tag from "@svicons/boxicons-solid/tag.svelte";
   import Tree from "@svicons/boxicons-solid/tree.svelte";
   import DonateHeart from "@svicons/boxicons-solid/donate-heart.svelte";
   import Shield from "@svicons/boxicons-solid/shield.svelte";
@@ -22,25 +25,32 @@
   import Dollar from "@svicons/boxicons-solid/badge-dollar.svelte";
   import Plane from "@svicons/boxicons-solid/plane-alt.svelte";
   import Unlink from "@svicons/boxicons-regular/unlink.svelte";
+  import Coffee from "@svicons/boxicons-solid/coffee.svelte";
+  import Group from "@svicons/boxicons-solid/group.svelte";
 
   import type { SvelteComponent } from "svelte";
 
   export type IconType =
     | "brain"
     | "bulb"
+    | "book"
     | "calendar"
     | "code"
+    | "coffee"
+    | "chalkboard"
     | "conversation"
     | "devices"
     | "edit"
     | "heart"
     | "question"
+    | "group"
     | "search"
     | "slideshow"
     | "transfer"
     | "vector"
     | "health"
     | "education"
+    | "tag"
     | "tree"
     | "donate"
     | "shield"
@@ -53,15 +63,20 @@
   const iconMap: Record<IconType, typeof SvelteComponent> = {
     brain: Brain,
     bulb: Bulb,
+    book: Book,
     calendar: Calendar,
     code: Code,
+    coffee: Coffee,
+    chalkboard: Chalkboard,
     conversation: Conversation,
     devices: Devices,
     edit: Edit,
     heart: Heart,
     question: Question,
+    group: Group,
     search: Search,
     slideshow: Slideshow,
+    tag: Tag,
     transfer: Transfer,
     vector: Vector,
     health: Health,

--- a/src/components/sponsors/Stats.svelte
+++ b/src/components/sponsors/Stats.svelte
@@ -1,13 +1,15 @@
 <div class="stats">
   <div class="stat">
-    <div class="val">91%</div>
-    <div>member retention rate</div>
+    <div class="val">50%</div>
+    <div>of leads are women</div>
   </div>
   <div class="stat">
     <div class="val">3 of 5</div>
     <div>directors are women</div>
   </div>
-  <div class="stat">
+  <div class="stat tall">
+    <div class="val">91%</div>
+    <div>member retention rate at&nbsp;a</div>
     <div class="val">top 5</div>
     <div>CS/ECE school</div>
   </div>
@@ -29,19 +31,21 @@
       product valuation by the 501(c)(3) nonprofit Love Without Boundaries
     </div>
   </div>
-  <div class="stat">
-    <div class="val">15%</div>
-    <div>members of underepresented backgrounds</div>
+  <div class="stat tall">
+    <div class="val">52%</div>
+    <div>Female</div>
+    <div class="val">48%</div>
+    <div>Male</div>
   </div>
 </div>
 
 <style>
   .stats {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: 1fr 0.5fr 1fr 1fr 0.5fr;
     grid-template-rows: repeat(2, 1fr);
-    grid-column-gap: 10px;
-    grid-row-gap: 10px;
+    gap: 10px;
+    grid-auto-flow: column;
     margin: 2rem 0 2rem;
   }
 
@@ -56,6 +60,10 @@
     box-sizing: border-box;
     border: 2px solid var(--blue-light);
     border-radius: 4px;
+  }
+
+  .stat.tall {
+    grid-row: 1 / 3;
   }
 
   .val {
@@ -74,6 +82,11 @@
     .stats {
       grid-template-columns: repeat(2, 1fr);
       grid-template-rows: max-content;
+      grid-auto-flow: row;
+    }
+
+    .stat.tall {
+      grid-row: unset;
     }
 
     .stat:nth-child(1n) {

--- a/src/routes/join/sponsors.svelte
+++ b/src/routes/join/sponsors.svelte
@@ -8,11 +8,13 @@
   import Info from "$components/sponsors/Info.svelte";
   import Stats from "$components/sponsors/Stats.svelte";
   import Testimonial from "$components/Testimonial.svelte";
-  import type {
-    FAQ,
-    Image,
-    Info as SiteInfo,
-    NonprofitTestimonialProject,
+  import {
+    Perk,
+    type FAQ,
+    type Image,
+    type Info as SiteInfo,
+    type NonprofitTestimonialProject,
+    type PerkType,
   } from "$utils/schema";
   import type { Load } from "@sveltejs/kit";
 
@@ -42,46 +44,36 @@
   interface SponsorTier {
     name: string;
     price: number;
-    perks: string[];
+    perks: PerkType[];
   }
 
-  let tiers: SponsorTier[] = [
+  const tiers: SponsorTier[] = [
     {
       name: "Standard",
-      price: 1500,
-      perks: ["Digital Branding", "Resume Book", "Coffee Chats"],
+      price: 2000,
+      perks: [Perk.RESUME_BOOK],
     },
     {
       name: "Plus",
-      price: 2000,
+      price: 3500,
       perks: [
-        "Digital Branding",
-        "Resume Book",
-        "Standard Session",
-        "Coffee Chats",
+        Perk.DIGITAL_BRANDING,
+        Perk.RESUME_BOOK,
+        Perk.STANDARD_SESSION,
+        Perk.COFFEE_CHATS,
       ],
     },
     {
       name: "Premier",
-      price: 2500,
+      price: 5000,
       perks: [
-        "Digital Branding",
-        "Resume Book",
-        "Premium Session",
-        "Coffee Chats",
-        "Fellowship Funding",
+        Perk.DIGITAL_BRANDING,
+        Perk.RESUME_BOOK,
+        Perk.PREMIUM_SESSION,
+        Perk.COFFEE_CHATS,
+        Perk.MENTORSHIP,
       ],
     },
-  ];
-
-  let allPerks: string[] = [
-    ...new Set(
-      tiers
-        .map((tier) => tier.perks)
-        .reduce((totalPerks: string[], perks: string[]) =>
-          totalPerks.concat(perks)
-        )
-    ),
   ];
 
   export let faqs: FAQ[];
@@ -185,7 +177,7 @@
           <h3>{tier.name} Sponsor</h3>
           <h4>${tier.price}/semester</h4>
           <ul>
-            {#each allPerks as perk}
+            {#each Object.values(Perk) as perk}
               <li class={tier.perks.includes(perk) ? "" : "disabled"}>
                 <span class="status">
                   {#if tier.perks.includes(perk)}
@@ -194,13 +186,30 @@
                     &times;
                   {/if}
                 </span>
-                {perk}
+                {perk.name}
               </li>
             {/each}
           </ul>
         </div>
       {/each}
     </Row>
+    <div class="perks">
+      {#each Object.values(Perk) as perk}
+        <article>
+          <div class="icon-container"><Icon icon={perk.icon} /></div>
+          <div>
+            <h2>{perk.name}</h2>
+            <h3>
+              {tiers
+                .filter(({ perks }) => perks.includes(perk))
+                .map((tier) => tier.name)
+                .join(", ")}
+            </h3>
+            <p>{perk.description}</p>
+          </div>
+        </article>
+      {/each}
+    </div>
   </span>
 </Section>
 
@@ -244,6 +253,7 @@
   p {
     opacity: 80%;
   }
+
   .light-text {
     color: #fff;
   }
@@ -258,17 +268,17 @@
     align-items: center;
   }
 
-  .sponsor-perks h3 {
+  .sponsor-perks .tier h3 {
     margin-top: 1rem;
     font-size: 1.6rem;
     margin-bottom: 0;
   }
 
-  .sponsor-perks h4 {
+  .sponsor-perks .tier h4 {
     font-size: 1.2rem;
   }
 
-  .sponsor-perks ul {
+  .sponsor-perks .tier ul {
     padding-left: 0;
     list-style: none;
     font-size: 1rem;
@@ -277,13 +287,13 @@
     text-align: left;
   }
 
-  .sponsor-perks ul > li.disabled {
+  .sponsor-perks .tier ul > li.disabled {
     opacity: 0.6;
     user-select: none;
     cursor: disabled;
   }
 
-  .sponsor-perks ul > li > .status {
+  .sponsor-perks .tier ul > li > .status {
     user-select: none;
     display: inline-block;
     margin-right: 0.75em;
@@ -331,6 +341,33 @@
 
   #by-the-numbers {
     color: white;
+  }
+
+  .perks {
+    display: flex;
+    flex-flow: row wrap;
+    gap: 25px 50px;
+    justify-content: center;
+    padding-block: 2rem;
+  }
+
+  .perks > article {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: flex-start;
+    gap: 15px;
+    max-width: 60ch;
+    flex: 1 0 50ch;
+  }
+
+  .perks > article h2 {
+    margin-bottom: 0;
+  }
+
+  .icon-container {
+    width: 3rem;
+    height: 3rem;
+    flex-shrink: 0;
   }
 
   :global(#areas-of-impact div > div > svg) {

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -110,17 +110,17 @@ export type PerkType = {
 };
 
 export const Perk: Record<string, PerkType> = {
-  DIGITAL_BRANDING: {
-    name: "Digital Branding",
-    icon: "tag",
-    description:
-      "Feature your company’s name and logo on our website, event pages, and social media.",
-  },
   RESUME_BOOK: {
     name: "Resume Book",
     icon: "book",
     description:
       "Gain access to our talented members via a digital resume book.",
+  },
+  DIGITAL_BRANDING: {
+    name: "Digital Branding",
+    icon: "tag",
+    description:
+      "Feature your company’s name and logo on our website, event pages, and social media.",
   },
   STANDARD_SESSION: {
     name: "Standard Session",

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,3 +1,5 @@
+import type { IconType } from "$components/Icon.svelte";
+
 export type Image = {
   src: string;
   alt: string;
@@ -100,6 +102,51 @@ export type NonprofitStep = {
   description: string;
   order: number;
 };
+
+export type PerkType = {
+  name: string;
+  icon: IconType;
+  description: string;
+};
+
+export const Perk: Record<string, PerkType> = {
+  DIGITAL_BRANDING: {
+    name: "Digital Branding",
+    icon: "tag",
+    description:
+      "Feature your company’s name and logo on our website, event pages, and social media.",
+  },
+  RESUME_BOOK: {
+    name: "Resume Book",
+    icon: "book",
+    description:
+      "Gain access to our talented members via a digital resume book.",
+  },
+  STANDARD_SESSION: {
+    name: "Standard Session",
+    icon: "group",
+    description:
+      "45 min session for a presentation on topic of your choice, Q&A, and networking with 40 attendees over Zoom.",
+  },
+  PREMIUM_SESSION: {
+    name: "Premium Session",
+    icon: "chalkboard",
+    description:
+      "1 hour session for a presentation on topic of your choice, Q&A, and networking with 40 attendees over Zoom.",
+  },
+  COFFEE_CHATS: {
+    name: "Coffee Chats",
+    icon: "coffee",
+    description:
+      "Opportunity to talk to our members in a more casual setting. Meet members in small groups for 30 minute Zoom sessions. We guarantee at least 20 members to sign up.",
+  },
+  MENTORSHIP: {
+    name: "Mentorship",
+    icon: "education",
+    description:
+      "Engineers, Product Managers, and/or Product Designers from the sponsoring company can be paired with our student teams to provide guidance and advice over the course of the semester.",
+  },
+} as const;
 
 // avoids unnecessary resizing of SVGs
 export function setImageHeight(src: string, height: number): string {


### PR DESCRIPTION
## Status:
:rocket: Ready

## Description
Updated the sponsors page to more closely reflect the most recent H4I sponsors infographic.
- Updated by the numbers section
- Updated the sponsorship tiers (pricing and perks) and added perk descriptions

I'd like to put the sponsorship tiers stuff on Contentful eventually, which is kinda why I extracted it from the file for the time being.

<img width="1280" alt="image" src="https://user-images.githubusercontent.com/23221268/181160637-f5c961b7-8548-4370-80da-3651a16e71bb.png">

![image](https://user-images.githubusercontent.com/23221268/181789647-8a58f895-a559-4d06-b507-28ab44c3a499.png)

<img width="966" alt="image" src="https://user-images.githubusercontent.com/23221268/181137706-487989da-bb01-4cc7-bbee-87694ac01d88.png">
