### PR TITLE
Add Vite env prefix value back and upgrade SvelteKit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@contentful/rich-text-html-renderer": "^15.0.0",
         "@contentful/rich-text-types": "^15.0.0",
         "@sveltejs/adapter-static": "1.0.0-next.37",
-        "@sveltejs/kit": "1.0.0-next.377",
+        "@sveltejs/kit": "1.0.0-next.379",
         "@types/ackee-tracker": "^5.0.1",
         "@types/html-minifier-terser": "^6.1.0",
         "@typescript-eslint/eslint-plugin": "^5.30.6",
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.0-next.377",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.377.tgz",
-      "integrity": "sha512-DH2v2yUBUuDZ7vzjPXUd/yt1AMR3BIkZN0ubLAvS2C+q5Wbvk7ZvAJhfPZ3OYc3ZpQXe4ZGEcptOjvEYvd1lLA==",
+      "version": "1.0.0-next.379",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.379.tgz",
+      "integrity": "sha512-mhy0GW4KUJ3tq6mDMF0fs/B6Nh2oJM6ZAA2fwilTOdqzhKD3f2WJLH9RXx1Z5/8eodFeQsURTPRn5a0r3QAZew==",
       "dev": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^1.0.1",
@@ -3644,9 +3644,9 @@
       }
     },
     "@sveltejs/kit": {
-      "version": "1.0.0-next.377",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.377.tgz",
-      "integrity": "sha512-DH2v2yUBUuDZ7vzjPXUd/yt1AMR3BIkZN0ubLAvS2C+q5Wbvk7ZvAJhfPZ3OYc3ZpQXe4ZGEcptOjvEYvd1lLA==",
+      "version": "1.0.0-next.379",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.379.tgz",
+      "integrity": "sha512-mhy0GW4KUJ3tq6mDMF0fs/B6Nh2oJM6ZAA2fwilTOdqzhKD3f2WJLH9RXx1Z5/8eodFeQsURTPRn5a0r3QAZew==",
       "dev": true,
       "requires": {
         "@sveltejs/vite-plugin-svelte": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@contentful/rich-text-html-renderer": "^15.0.0",
     "@contentful/rich-text-types": "^15.0.0",
     "@sveltejs/adapter-static": "1.0.0-next.37",
-    "@sveltejs/kit": "1.0.0-next.377",
+    "@sveltejs/kit": "1.0.0-next.379",
     "@types/ackee-tracker": "^5.0.1",
     "@types/html-minifier-terser": "^6.1.0",
     "@typescript-eslint/eslint-plugin": "^5.30.6",

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,7 @@ import { resolve } from "path";
 
 export default defineConfig({
   plugins: [sveltekit()],
+  envPrefix: "CLIENT_",
   resolve: {
     alias: {
       $utils: resolve("./src/utils"),


### PR DESCRIPTION
## Status:
:rocket: Ready

## Description
In the SvelteKit upgrade PR where I removed the `envPrefix` setting from Vite, it was to get around a SvelteKit bug with the `envPrefix` attribute. I didn't update the GitHub actions workflows to respect the default prefix of `VITE_` for some reason, so the variables haven't been passed in recent builds. I'm opening this PR to upgrade SvelteKit to a version where the `envPrefix` setting is patched, and I'm adding the `CLIENT_` `envPrefix` back (so the workflows don't have to be changed).