### PR TITLE
Rename open positions to roles

### DIFF
--- a/src/routes/join/students.svelte
+++ b/src/routes/join/students.svelte
@@ -10,9 +10,9 @@
   import type { Load } from "@sveltejs/kit";
 
   export const load: Load = async ({ fetch }) => {
-    const [faqs, openRoles, applicationSteps, info] = (await Promise.all([
+    const [faqs, visibleRoles, applicationSteps, info] = (await Promise.all([
       fetch("/server/apply-faq.json").then((res: Response) => res.json()),
-      fetch("/server/open-roles.json").then((res: Response) => res.json()),
+      fetch("/server/visible-roles.json").then((res: Response) => res.json()),
       fetch("/server/application-steps.json").then((res: Response) =>
         res.json()
       ),
@@ -24,7 +24,7 @@
     return {
       props: {
         faqs,
-        openRoles,
+        visibleRoles,
         applicationSteps,
         applicationBlurb,
         projectsImage: info.homepagePartnerships,
@@ -35,7 +35,7 @@
 
 <script lang="ts">
   export let faqs: FAQ[];
-  export let openRoles: Role[];
+  export let visibleRoles: Role[];
   export let applicationSteps: ApplicationStep[];
   export let applicationBlurb: string;
   export let projectsImage: Image;
@@ -64,14 +64,14 @@
   </p>
 </Section>
 
-{#if openRoles.length > 0}
+{#if visibleRoles.length > 0}
   <Section id="open-positions" color="var(--blue)" padding="60px">
     <span class="light-text wrap">
       <h2>Roles</h2>
-      {#each openRoles as openRole}
+      {#each visibleRoles as role}
         <Accordion theme="light">
-          <span slot="title">{openRole.name}</span>
-          <span slot="contents">{@html openRole.description}</span>
+          <span slot="title">{role.name}</span>
+          <span slot="contents">{@html role.description}</span>
         </Accordion>
       {/each}
     </span>

--- a/src/routes/join/students.svelte
+++ b/src/routes/join/students.svelte
@@ -67,7 +67,7 @@
 {#if openRoles.length > 0}
   <Section id="open-positions" color="var(--blue)" padding="60px">
     <span class="light-text wrap">
-      <h2>Open Positions</h2>
+      <h2>Roles</h2>
       {#each openRoles as openRole}
         <Accordion theme="light">
           <span slot="title">{openRole.name}</span>

--- a/src/routes/server/visible-roles.json.ts
+++ b/src/routes/server/visible-roles.json.ts
@@ -3,12 +3,12 @@ import type { Role } from "$utils/schema";
 import type { RequestHandler } from "@sveltejs/kit";
 
 export const GET: RequestHandler = async () => {
-  const faqs: Role[] = await contentWrapper.get("role", {
+  const roles: Role[] = await contentWrapper.get("role", {
     order: "fields.name",
-    "fields.open": true,
+    "fields.visible": true,
   });
 
   return {
-    body: faqs,
+    body: roles,
   };
 };


### PR DESCRIPTION
## Status:
:rocket: Ready
## Description

This change is small but does a lot. We wanted a way to show a short description of important roles on the students page. By removing the word "open," we can leave the software dev and product designer roles available to view the entire year. I think it benefits us to have a description of such roles on this page at all times. The application process section below is more clear about what can be applied to. If we are recruiting for another role, we can just display it in the "Roles" section too, though other roles will only be displayed if applicable. In the code, I changed any instance of "open role" to "visible role" to match the new idea.

I also just decided to use the word roles because I think it's clearer overall.

Let me know your thoughts.