### PR TITLE
Fix featured project banner opacity

### DIFF
--- a/src/components/projects/FeaturedBanner.svelte
+++ b/src/components/projects/FeaturedBanner.svelte
@@ -29,8 +29,7 @@
     margin-bottom: 20px;
   }
 
-  h4,
-  a {
+  h4 {
     opacity: 80%;
   }
 


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready

## Description

Featured project banners were (mistakenly) shown at 80% opacity and looked sort of washed out. Improves contrast/readability of banner info.

## Screenshots

<table>
<tr>
<th>Current (80% Opacity) &lt;main&gt;</th>
<th>Changes (True color) &lt;fix-featured-project-opacity&gt;</th>
</tr>
<tr>
<td><img width="1039" alt="Screen Shot 2022-08-29 at 1 29 13 PM" src="https://user-images.githubusercontent.com/19193347/187292926-f66b120e-7664-4bfb-9003-9f2398157241.png"></td>
<td><img width="1062" alt="Screen Shot 2022-08-29 at 1 29 08 PM" src="https://user-images.githubusercontent.com/19193347/187292951-0b7cae5e-7d39-4c03-9fe6-4d12910fa3ac.png"></td>
</tr>
<tr>
<td>
<img width="1050" alt="Screen Shot 2022-08-29 at 1 28 55 PM" src="https://user-images.githubusercontent.com/19193347/187292939-906e2b00-ca7d-4455-b0bc-b71982bdc901.png"></td>
<td>

<img width="1064" alt="Screen Shot 2022-08-29 at 1 29 00 PM" src="https://user-images.githubusercontent.com/19193347/187292960-981c5121-6508-4cc5-8b0e-e7fe11ec90fc.png">
</td>

</tr>
</table>

