### PR TITLE
Support rectangular member images

### DIFF
--- a/src/components/Member.svelte
+++ b/src/components/Member.svelte
@@ -23,6 +23,8 @@
     max-width: 30%;
     height: auto;
     margin-right: 5%;
+    aspect-ratio: 1;
+    object-fit: cover;
   }
 
   h4 {


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready

## Description

Rectangular headshots pulled from Contentful are stretched out and ovular. We can fix the aspect ratio to 1:1 and set the image to fit as a cover.

## Screenshots

<table>
<tr>
<th>Current &lt;main&gt;</th>
<th>Changes &lt;rectangular-member-images&gt;</th>
</tr>
<tr>
<td>
<img width="931" alt="Screen Shot 2022-08-29 at 2 05 25 PM" src="https://user-images.githubusercontent.com/19193347/187299388-59e3a7e8-3a5b-4cec-8b67-4cad126a723d.png">

</td>
<td>
<img width="926" alt="Screen Shot 2022-08-29 at 2 05 19 PM" src="https://user-images.githubusercontent.com/19193347/187299407-10353177-4d85-42ba-816b-20d0c9e11b91.png">

</td>
</tr>
</table>