### PR TITLE
Better handle roles section title on students join page

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -80,6 +80,10 @@
         }
       }
 
+      * {
+        scroll-margin-top: 45px;
+      }
+
       body {
         margin: 0;
         font-family: var(--fonts-body);

--- a/src/components/Accordion.svelte
+++ b/src/components/Accordion.svelte
@@ -41,7 +41,7 @@
   }
 
   .summary {
-    flex: 1 0 auto;
+    flex: 1;
     height: 100%;
     border: none;
     cursor: pointer;

--- a/src/components/Accordion.svelte
+++ b/src/components/Accordion.svelte
@@ -32,6 +32,7 @@
     flex-flow: row nowrap;
     align-items: flex-end;
     justify-content: space-between;
+    gap: 5px;
     width: 100%;
     border-bottom: 1px solid var(--blue);
   }

--- a/src/components/Accordion.svelte
+++ b/src/components/Accordion.svelte
@@ -14,6 +14,7 @@
 
 <button class="accordion" on:click={toggle} class:light={theme === "light"}>
   <h3>{open ? "−" : "+"} <slot name="title" /></h3>
+  <slot name="actions" />
 </button>
 {#if open}
   <div class="panel" transition:slide={{ duration: 150 }}>
@@ -23,6 +24,10 @@
 
 <style>
   .accordion {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: flex-end;
+    justify-content: space-between;
     width: 100%;
     border: none;
     cursor: pointer;

--- a/src/components/Accordion.svelte
+++ b/src/components/Accordion.svelte
@@ -12,10 +12,14 @@
   }
 </script>
 
-<button class="accordion" on:click={toggle} class:light={theme === "light"}>
-  <h3>{open ? "−" : "+"} <slot name="title" /></h3>
-  <slot name="actions" />
-</button>
+<div class="accordion" class:light={theme === "light"}>
+  <button class="summary" on:click={toggle}>
+    <h3>{open ? "−" : "+"} <slot name="title" /></h3>
+  </button>
+  <div>
+    <slot name="actions" />
+  </div>
+</div>
 {#if open}
   <div class="panel" transition:slide={{ duration: 150 }}>
     <slot name="contents" />
@@ -29,14 +33,21 @@
     align-items: flex-end;
     justify-content: space-between;
     width: 100%;
+    border-bottom: 1px solid var(--blue);
+  }
+
+  .accordion > * {
+    padding: 20px 0;
+  }
+
+  .summary {
+    flex: 1 0 auto;
+    height: 100%;
     border: none;
     cursor: pointer;
     background-color: transparent;
     border: none;
     outline: none;
-    border-bottom: 1px solid var(--blue);
-    text-align: left;
-    padding: 20px 0;
   }
 
   .panel {
@@ -46,13 +57,14 @@
   h3 {
     color: var(--blue);
     margin: 0;
+    text-align: start;
   }
 
-  button.light > h3 {
+  .light h3 {
     color: var(--gray-lighter);
   }
 
-  .accordion.light {
+  .light {
     border-color: var(--gray-lighter);
   }
 </style>

--- a/src/components/RoleInfo.svelte
+++ b/src/components/RoleInfo.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Role } from "$utils/schema";
   import Accordion from "./Accordion.svelte";
+  import Button from "./Button.svelte";
 
   export let role: Role;
 </script>
@@ -9,6 +10,12 @@
   <span slot="title">
     {role.name}
   </span>
-  <slot name="actions" slot="actions" />
+  <svelte:fragment slot="actions">
+    {#if role.open}
+      <a href="#process">
+        <Button type="primary-white">Apply</Button>
+      </a>
+    {/if}
+  </svelte:fragment>
   <span slot="contents">{@html role.description}</span>
 </Accordion>

--- a/src/components/RoleInfo.svelte
+++ b/src/components/RoleInfo.svelte
@@ -9,5 +9,6 @@
   <span slot="title">
     {role.name}
   </span>
+  <slot name="actions" slot="actions" />
   <span slot="contents">{@html role.description}</span>
 </Accordion>

--- a/src/routes/join/students.svelte
+++ b/src/routes/join/students.svelte
@@ -71,11 +71,7 @@
     <span class="light-text wrap">
       <h2>Open Positions</h2>
       {#each visibleRoles as role}
-        <RoleInfo {role}>
-          <a href="#process" slot="actions">
-            <Button type="primary-white">Apply</Button>
-          </a>
-        </RoleInfo>
+        <RoleInfo {role} />
       {/each}
     </span>
   </Section>

--- a/src/routes/join/students.svelte
+++ b/src/routes/join/students.svelte
@@ -47,10 +47,6 @@
     Form: "edit",
     Interview: "conversation",
   };
-
-  $: openRoles = visibleRoles.filter((role) => role.open);
-  $: otherRoles = visibleRoles.filter((role) => !role.open);
-  $: anyOpenRoles = openRoles.length > 0;
 </script>
 
 <Head
@@ -73,26 +69,18 @@
 {#if visibleRoles.length > 0}
   <Section id="positions" color="var(--blue)" padding="60px">
     <span class="light-text wrap">
-      {#if anyOpenRoles}
-        <Section id="open-positions" color="var(--blue)">
-          <h2>Open Roles</h2>
-          {#each openRoles as role}
-            <RoleInfo {role} />
-          {/each}
-        </Section>
-      {/if}
-      {#if otherRoles.length > 0}
-        <Section
-          id="other-positions"
-          color="var(--blue)"
-          padding={anyOpenRoles ? "60px 0 0" : undefined}
-        >
-          <h2>{anyOpenRoles ? "Other " : ""}Roles</h2>
-          {#each otherRoles as role}
-            <RoleInfo {role} />
-          {/each}
-        </Section>
-      {/if}
+      <h2>Open Positions</h2>
+      {#each visibleRoles as role}
+        <RoleInfo {role}>
+          <a
+            href="#process"
+            slot="actions"
+            on:click={(e) => e.stopPropagation()}
+          >
+            <Button type="primary-white">Apply</Button>
+          </a>
+        </RoleInfo>
+      {/each}
     </span>
   </Section>
 {/if}

--- a/src/routes/join/students.svelte
+++ b/src/routes/join/students.svelte
@@ -72,11 +72,7 @@
       <h2>Open Positions</h2>
       {#each visibleRoles as role}
         <RoleInfo {role}>
-          <a
-            href="#process"
-            slot="actions"
-            on:click={(e) => e.stopPropagation()}
-          >
+          <a href="#process" slot="actions">
             <Button type="primary-white">Apply</Button>
           </a>
         </RoleInfo>

--- a/src/routes/join/students.svelte
+++ b/src/routes/join/students.svelte
@@ -50,6 +50,7 @@
 
   $: openRoles = visibleRoles.filter((role) => role.open);
   $: otherRoles = visibleRoles.filter((role) => !role.open);
+  $: anyOpenRoles = openRoles.length > 0;
 </script>
 
 <Head
@@ -72,7 +73,7 @@
 {#if visibleRoles.length > 0}
   <Section id="positions" color="var(--blue)" padding="60px">
     <span class="light-text wrap">
-      {#if openRoles.length > 0}
+      {#if anyOpenRoles}
         <Section id="open-positions" color="var(--blue)">
           <h2>Open Roles</h2>
           {#each openRoles as role}
@@ -81,8 +82,12 @@
         </Section>
       {/if}
       {#if otherRoles.length > 0}
-        <Section id="other-positions" color="var(--blue)" padding="60px 0 0">
-          <h2>Other Roles</h2>
+        <Section
+          id="other-positions"
+          color="var(--blue)"
+          padding={anyOpenRoles ? "60px 0 0" : undefined}
+        >
+          <h2>{anyOpenRoles ? "Other " : ""}Roles</h2>
           {#each otherRoles as role}
             <RoleInfo {role} />
           {/each}

--- a/src/routes/server/visible-roles.json.ts
+++ b/src/routes/server/visible-roles.json.ts
@@ -4,7 +4,7 @@ import type { RequestHandler } from "@sveltejs/kit";
 
 export const GET: RequestHandler = async () => {
   const roles: Role[] = await contentWrapper.get("role", {
-    order: "fields.open",
+    order: "-fields.open",
     "fields.visible": true,
   });
 


### PR DESCRIPTION
## Status:

:rocket: Ready

## Description

More accurately handle "Role" section titles on students join page. There are three cases:
- A role is "open," which means it goes under a section with the title "Open Roles"
- A role is not open while another role is open, which means it goes under a section with the title "Other Roles"
- A role is not open when no other roles are open, which means it goes under a section with the title "Roles"

## Screenshots

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/23221268/196062584-d45714da-5768-47e1-9636-2126167f865d.png">

<img width="1209" alt="image" src="https://user-images.githubusercontent.com/23221268/196062595-f8da1665-bd4a-4187-afeb-b43ead114f7e.png">

