### PR TITLE
Remove scroll anchors and place IDs on headings for hash changes

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -81,7 +81,7 @@
       }
 
       * {
-        scroll-margin-top: 45px;
+        scroll-margin-top: 85px;
       }
 
       body {

--- a/src/routes/join/students.svelte
+++ b/src/routes/join/students.svelte
@@ -77,8 +77,8 @@
   </Section>
 {/if}
 
-<Section id="process" color="var(--gray-lighter)" padding="40px">
-  <h2>Application Process</h2>
+<Section color="var(--gray-lighter)" padding="40px">
+  <h2 id="process">Application Process</h2>
   <p>{@html applicationBlurb}</p>
   <div id="process-steps">
     {#each applicationSteps as step}

--- a/src/routes/projects/index.svelte
+++ b/src/routes/projects/index.svelte
@@ -81,8 +81,7 @@
       {#each semesters as semester, idx}
         {@const featured = projectMap[semester].featured}
         <section class="semester-section">
-          <span class="scroll-anchor" id={semesterToId(semester)} />
-          <h2>{semester}</h2>
+          <h2 id={semesterToId(semester)}>{semester}</h2>
           {#if featured}
             <FeaturedBanner project={featured} />
           {/if}
@@ -104,11 +103,6 @@
     position: relative;
   }
 
-  .semester-section .scroll-anchor {
-    position: absolute;
-    top: -87px;
-  }
-
   .semester-section:first-child {
     margin-top: 0;
   }
@@ -127,10 +121,6 @@
     .col-wrapper {
       grid-template-columns: 1fr;
       grid-template-rows: 1fr, 1fr;
-    }
-
-    .semester-section .scroll-anchor {
-      top: -135px;
     }
   }
 

--- a/src/routes/projects/index.svelte
+++ b/src/routes/projects/index.svelte
@@ -158,6 +158,10 @@
     article {
       margin-top: 2em;
     }
+
+    .semester-section > h2 {
+      scroll-margin-top: calc(60px + 0.25em + 85px);
+    }
   }
 
   @media only screen and (max-width: 792px) {


### PR DESCRIPTION
## Status:

🚀  : Ready

## Description

Removes elements used only for hash-navigation since the site now sets a global `scroll-margin-top: 85px`. I also moved some IDs used for hash-navigation to heading elements to align the heading up with the top of the screen, rather than the containing section (which sometimes had padding).

## Screenshots

https://user-images.githubusercontent.com/23221268/197369158-3aba2c0b-c4d1-4c0c-80b1-be51ba2daa5d.mov
