### PR TITLE
Support content preview

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -64,6 +64,8 @@ jobs:
         env:
           CONTENTFUL_DELIVERY_KEY: ${{ secrets.CONTENTFUL_DELIVERY_KEY }}
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+          CONTENTFUL_PREVIEW_KEY: ${{ secrets.CONTENTFUL_PREVIEW_KEY }}
+          CONTENTFUL_PREVIEW_FLAG: ${{ secrets.CONTENTFUL_PREVIEW_FLAG }}
         run: npm run check
 
   build:
@@ -87,6 +89,8 @@ jobs:
         env:
           CONTENTFUL_DELIVERY_KEY: ${{ secrets.CONTENTFUL_DELIVERY_KEY }}
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+          CONTENTFUL_PREVIEW_KEY: ${{ secrets.CONTENTFUL_PREVIEW_KEY }}
+          CONTENTFUL_PREVIEW_FLAG: ${{ secrets.CONTENTFUL_PREVIEW_FLAG }}
           CLIENT_ACKEE_URL: ${{ secrets.CLIENT_ACKEE_URL }}
           CLIENT_ACKEE_DOMAIN_ID: ${{ secrets.CLIENT_ACKEE_DOMAIN_ID }}
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
         env:
           CONTENTFUL_DELIVERY_KEY: ${{ secrets.CONTENTFUL_DELIVERY_KEY }}
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+          CONTENTFUL_PREVIEW_KEY: ${{ secrets.CONTENTFUL_PREVIEW_KEY }}
+          CONTENTFUL_PREVIEW_FLAG: ${{ secrets.CONTENTFUL_PREVIEW_FLAG }}
         run: npm run check
 
   build:
@@ -87,6 +89,8 @@ jobs:
         env:
           CONTENTFUL_DELIVERY_KEY: ${{ secrets.CONTENTFUL_DELIVERY_KEY }}
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+          CONTENTFUL_PREVIEW_KEY: ${{ secrets.CONTENTFUL_PREVIEW_KEY }}
+          CONTENTFUL_PREVIEW_FLAG: ${{ secrets.CONTENTFUL_PREVIEW_FLAG }}
           CLIENT_ACKEE_URL: ${{ secrets.CLIENT_ACKEE_URL }}
           CLIENT_ACKEE_DOMAIN_ID: ${{ secrets.CLIENT_ACKEE_DOMAIN_ID }}
         run: npm run build

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -64,6 +64,8 @@ jobs:
         env:
           CONTENTFUL_DELIVERY_KEY: ${{ secrets.CONTENTFUL_DELIVERY_KEY }}
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+          CONTENTFUL_PREVIEW_KEY: ${{ secrets.CONTENTFUL_PREVIEW_KEY }}
+          CONTENTFUL_PREVIEW_FLAG: ${{ secrets.CONTENTFUL_PREVIEW_FLAG }}
         run: npm run check
 
   build:
@@ -87,6 +89,8 @@ jobs:
         env:
           CONTENTFUL_DELIVERY_KEY: ${{ secrets.CONTENTFUL_DELIVERY_KEY }}
           CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
+          CONTENTFUL_PREVIEW_KEY: ${{ secrets.CONTENTFUL_PREVIEW_KEY }}
+          CONTENTFUL_PREVIEW_FLAG: ${{ secrets.CONTENTFUL_PREVIEW_FLAG }}
           CLIENT_ACKEE_URL: ${{ secrets.CLIENT_ACKEE_URL }}
           CLIENT_ACKEE_DOMAIN_ID: ${{ secrets.CLIENT_ACKEE_DOMAIN_ID }}
         run: npm run build

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -4,7 +4,9 @@
 // for information about these interfaces
 // and what to do when importing types
 declare namespace App {
-  // interface Locals {}
+  interface Locals {
+    contentWrapper: import("$lib/utils/api").ContentWrapper;
+  }
   // interface Error {}
   interface PageData {
     // This page data value is used as the start of the page title by the root layout

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,6 +1,19 @@
 import { minify, type Options } from "html-minifier-terser";
 import { building } from "$app/environment";
 import type { Handle } from "@sveltejs/kit";
+import {
+  CONTENTFUL_DELIVERY_KEY,
+  CONTENTFUL_PREVIEW_FLAG,
+  CONTENTFUL_PREVIEW_KEY,
+  CONTENTFUL_SPACE_ID,
+} from "$env/static/private";
+import { ContentWrapper } from "$lib/utils/api";
+
+const contentfulPreviewSearchParam = "preview";
+
+const isPreview = (url: URL) =>
+  url.searchParams.get(contentfulPreviewSearchParam) ===
+  CONTENTFUL_PREVIEW_FLAG;
 
 const minificationOptions: Options = {
   collapseBooleanAttributes: true,
@@ -15,6 +28,12 @@ const minificationOptions: Options = {
 };
 
 export const handle: Handle = async ({ event, resolve }) => {
+  event.locals.contentWrapper = new ContentWrapper(
+    CONTENTFUL_SPACE_ID,
+    CONTENTFUL_DELIVERY_KEY,
+    isPreview(event.url) ? CONTENTFUL_PREVIEW_KEY : undefined
+  );
+
   const response = await resolve(event);
 
   if (building && response.headers.get("content-type") === "text/html") {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -31,7 +31,7 @@ export const handle: Handle = async ({ event, resolve }) => {
   event.locals.contentWrapper = new ContentWrapper(
     CONTENTFUL_SPACE_ID,
     CONTENTFUL_DELIVERY_KEY,
-    isPreview(event.url) ? CONTENTFUL_PREVIEW_KEY : undefined
+    !building && isPreview(event.url) ? CONTENTFUL_PREVIEW_KEY : undefined
   );
 
   const response = await resolve(event);

--- a/src/lib/content/contentful.ts
+++ b/src/lib/content/contentful.ts
@@ -1,16 +1,9 @@
-import {
-  CONTENTFUL_DELIVERY_KEY,
-  CONTENTFUL_SPACE_ID,
-} from "$env/static/private";
-import { ContentWrapper } from "$lib/utils/api";
+import type { ContentWrapper } from "$lib/utils/api";
 import type { NonprofitTestimonialProject, Project } from "$lib/utils/schema";
 
-export const contentWrapper = new ContentWrapper(
-  CONTENTFUL_SPACE_ID,
-  CONTENTFUL_DELIVERY_KEY
-);
-
-export async function getTestimonialNonprofit(): Promise<NonprofitTestimonialProject> {
+export async function getTestimonialNonprofit(
+  contentWrapper: ContentWrapper
+): Promise<NonprofitTestimonialProject> {
   const projects: Project[] = await contentWrapper.get("project");
   const testimonialProjects = projects.filter(
     (project) =>

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -4,6 +4,9 @@ import type { ContentfulClientApi, ContentType, Entry } from "contentful";
 import contentful from "contentful";
 
 type ContentWrapperGetOptions = {
+  /**
+   * Use draft data from the Contentful preview API if the ContentWrapper is authorized to do so.
+   */
   preview: boolean;
 };
 

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -7,7 +7,7 @@ type ContentWrapperGetOptions = {
   /**
    * Use draft data from the Contentful preview API if the ContentWrapper is authorized to do so.
    */
-  preview: boolean;
+  allowPreview: boolean;
 };
 
 export class ContentWrapper {
@@ -29,11 +29,11 @@ export class ContentWrapper {
   async get(
     entity: string,
     contentfulOptions: any = {},
-    { preview = false }: ContentWrapperGetOptions = { preview: false }
+    { allowPreview = false }: ContentWrapperGetOptions = { allowPreview: false }
   ): Promise<any[]> {
     let client = this.client;
 
-    if (preview && this.previewClient) {
+    if (allowPreview && this.previewClient) {
       client = this.previewClient;
     }
 

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,20 +1,20 @@
-import { contentWrapper } from "$lib/content/contentful";
+import type { ContentWrapper } from "$lib/utils/api";
 import { generateProjectsInfo } from "$lib/utils/projects";
 import type { Info, Project } from "$lib/utils/schema";
 import type { LayoutServerLoad } from "./$types";
 
 export const prerender = true;
 
-export const load: LayoutServerLoad = () => {
+export const load: LayoutServerLoad = ({ locals }) => {
   return {
-    semesters: getSemesters(),
-    info: contentWrapper
+    semesters: getSemesters(locals.contentWrapper),
+    info: locals.contentWrapper
       .get("info")
       .then((infoList) => infoList[0]) as Promise<Info>,
   };
 };
 
-async function getSemesters() {
+async function getSemesters(contentWrapper: ContentWrapper) {
   const projects: Project[] = await contentWrapper.get("project");
 
   const { semesters } = generateProjectsInfo(projects);

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,15 +1,15 @@
-import { contentWrapper } from "$lib/content/contentful";
+import type { ContentWrapper } from "$lib/utils/api";
 import { shuffleArray } from "$lib/utils/projects";
 import type { Project } from "$lib/utils/schema";
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = () => {
+export const load: PageServerLoad = ({ locals }) => {
   return {
-    projects: getFeaturedProjects(),
+    projects: getFeaturedProjects(locals.contentWrapper),
   };
 };
 
-async function getFeaturedProjects() {
+async function getFeaturedProjects(contentWrapper: ContentWrapper) {
   const projects: Project[] = await contentWrapper.get("project", {
     "fields.featured": true,
   });

--- a/src/routes/about/+page.server.ts
+++ b/src/routes/about/+page.server.ts
@@ -1,15 +1,15 @@
-import { contentWrapper } from "$lib/content/contentful";
+import type { ContentWrapper } from "$lib/utils/api";
 import type { Member, TestimonialMember } from "$lib/utils/schema";
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = () => {
+export const load: PageServerLoad = ({ locals }) => {
   return {
     title: "About Us",
-    testimonialMember: getTestimonialMember(),
+    testimonialMember: getTestimonialMember(locals.contentWrapper),
   };
 };
 
-async function getTestimonialMember() {
+async function getTestimonialMember(contentWrapper: ContentWrapper) {
   const members: Member[] = await contentWrapper.get("member");
   const testimonialMembers = members.filter(
     (member) => member.testimonial !== undefined

--- a/src/routes/about/team/+page.server.ts
+++ b/src/routes/about/team/+page.server.ts
@@ -1,15 +1,15 @@
-import { contentWrapper } from "$lib/content/contentful";
+import type { ContentWrapper } from "$lib/utils/api";
 import type { Member } from "src/lib/utils/schema";
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = () => {
+export const load: PageServerLoad = ({ locals }) => {
   return {
     title: "The Team",
-    members: getMembers(),
+    members: getMembers(locals.contentWrapper),
   };
 };
 
-async function getMembers() {
+async function getMembers(contentWrapper: ContentWrapper) {
   const members: Member[] = await contentWrapper.get("member", {
     order: "fields.name",
     limit: 1000,

--- a/src/routes/about/work/+page.server.ts
+++ b/src/routes/about/work/+page.server.ts
@@ -1,10 +1,9 @@
-import { contentWrapper } from "$lib/content/contentful";
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = () => {
+export const load: PageServerLoad = ({ locals }) => {
   return {
     title: "How We Work",
-    faqs: contentWrapper.get("faq", {
+    faqs: locals.contentWrapper.get("faq", {
       order: "fields.order",
       "fields.category": "Work",
     }),

--- a/src/routes/images/people/[name].jpg/+server.ts
+++ b/src/routes/images/people/[name].jpg/+server.ts
@@ -1,12 +1,11 @@
-import { contentWrapper } from "$lib/content/contentful";
 import { setImageHeight, titleCase, type Member } from "$lib/utils/schema";
 import { error } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
-export const GET: RequestHandler = async ({ params, fetch, url }) => {
+export const GET: RequestHandler = async ({ params, fetch, url, locals }) => {
   const contentfulName = titleCase(params.name.replace("_", " "));
 
-  const members: Member[] = await contentWrapper.get("member", {
+  const members: Member[] = await locals.contentWrapper.get("member", {
     "fields.name": contentfulName,
   });
 

--- a/src/routes/images/projects/[slug].jpg/+server.ts
+++ b/src/routes/images/projects/[slug].jpg/+server.ts
@@ -1,10 +1,9 @@
-import { contentWrapper } from "$lib/content/contentful";
 import { setImageHeight, type Project } from "$lib/utils/schema";
 import { error } from "@sveltejs/kit";
 import type { RequestHandler } from "./$types";
 
-export const GET: RequestHandler = async ({ params, fetch, url }) => {
-  const projects: Project[] = await contentWrapper.get("project", {
+export const GET: RequestHandler = async ({ params, fetch, url, locals }) => {
+  const projects: Project[] = await locals.contentWrapper.get("project", {
     "fields.slug": params.slug,
   });
 

--- a/src/routes/join/nonprofits/+page.server.ts
+++ b/src/routes/join/nonprofits/+page.server.ts
@@ -1,20 +1,17 @@
-import {
-  contentWrapper,
-  getTestimonialNonprofit,
-} from "$lib/content/contentful";
+import { getTestimonialNonprofit } from "$lib/content/contentful";
 import type { FAQ, NonprofitStep } from "$lib/utils/schema";
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = () => {
+export const load: PageServerLoad = ({ locals }) => {
   return {
     title: "Nonprofits",
-    faqs: contentWrapper.get("faq", {
+    faqs: locals.contentWrapper.get("faq", {
       order: "fields.order",
       "fields.category": "Work",
     }) as Promise<FAQ[]>,
-    applicationSteps: contentWrapper.get("nonprofitStep", {
+    applicationSteps: locals.contentWrapper.get("nonprofitStep", {
       order: "fields.order",
     }) as Promise<NonprofitStep[]>,
-    testimonialNonprofit: getTestimonialNonprofit(),
+    testimonialNonprofit: getTestimonialNonprofit(locals.contentWrapper),
   };
 };

--- a/src/routes/join/sponsors/+page.server.ts
+++ b/src/routes/join/sponsors/+page.server.ts
@@ -1,18 +1,14 @@
-import {
-  contentWrapper,
-  getTestimonialNonprofit,
-} from "$lib/content/contentful";
+import { getTestimonialNonprofit } from "$lib/content/contentful";
 import type { FAQ } from "$lib/utils/schema";
-
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = () => {
+export const load: PageServerLoad = ({ locals }) => {
   return {
     title: "Sponsors",
-    faqs: contentWrapper.get("faq", {
+    faqs: locals.contentWrapper.get("faq", {
       order: "fields.order",
       "fields.category": "Sponsor",
     }) as Promise<FAQ[]>,
-    testimonialNonprofit: getTestimonialNonprofit(),
+    testimonialNonprofit: getTestimonialNonprofit(locals.contentWrapper),
   };
 };

--- a/src/routes/join/students/+page.server.ts
+++ b/src/routes/join/students/+page.server.ts
@@ -1,19 +1,18 @@
-import { contentWrapper } from "$lib/content/contentful";
 import type { ApplicationStep, FAQ, Role } from "src/lib/utils/schema";
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = () => {
+export const load: PageServerLoad = ({ locals }) => {
   return {
     title: "Students",
-    faqs: contentWrapper.get("faq", {
+    faqs: locals.contentWrapper.get("faq", {
       order: "fields.order",
       "fields.category": "Apply",
     }) as Promise<FAQ[]>,
-    visibleRoles: contentWrapper.get("role", {
+    visibleRoles: locals.contentWrapper.get("role", {
       order: "-fields.open",
       "fields.visible": true,
     }) as Promise<Role[]>,
-    applicationSteps: contentWrapper.get("applicationStep", {
+    applicationSteps: locals.contentWrapper.get("applicationStep", {
       order: "fields.startDate,fields.name",
     }) as Promise<ApplicationStep[]>,
   };

--- a/src/routes/projects/+page.server.ts
+++ b/src/routes/projects/+page.server.ts
@@ -1,16 +1,16 @@
-import { contentWrapper } from "$lib/content/contentful";
+import type { ContentWrapper } from "$lib/utils/api";
 import { generateProjectsInfo } from "$lib/utils/projects";
 import type { Project } from "$lib/utils/schema";
 import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = () => {
+export const load: PageServerLoad = ({ locals }) => {
   return {
     title: "Projects",
-    projectsInfo: getProjectsInfo(),
+    projectsInfo: getProjectsInfo(locals.contentWrapper),
   };
 };
 
-async function getProjectsInfo() {
+async function getProjectsInfo(contentWrapper: ContentWrapper) {
   const projects: Project[] = await contentWrapper.get("project", {
     order: "fields.name",
     limit: 1000,

--- a/src/routes/projects/[slug]/+page.server.ts
+++ b/src/routes/projects/[slug]/+page.server.ts
@@ -1,4 +1,3 @@
-import { contentWrapper } from "$lib/content/contentful";
 import { error } from "@sveltejs/kit";
 import type { Project } from "src/lib/utils/schema";
 import type { PageServerLoad } from "./$types";
@@ -8,10 +7,14 @@ import type { PageServerLoad } from "./$types";
 // TODO: Actually hook into Contentful preview API by changing contentWrapper
 export const prerender = "auto";
 
-export const load: PageServerLoad = async ({ params }) => {
-  const projects: Project[] = await contentWrapper.get("project", {
-    "fields.slug": params.slug,
-  });
+export const load: PageServerLoad = async ({ params, locals }) => {
+  const projects: Project[] = await locals.contentWrapper.get(
+    "project",
+    {
+      "fields.slug": params.slug,
+    },
+    { preview: true }
+  );
 
   if (projects.length === 0) {
     throw error(404);

--- a/src/routes/projects/[slug]/+page.server.ts
+++ b/src/routes/projects/[slug]/+page.server.ts
@@ -4,7 +4,6 @@ import type { PageServerLoad } from "./$types";
 
 // Prerender all projects found by SvelteKit crawler (displayed in projects page)
 // But include server-side JS to load any projects not found (preview projects)
-// TODO: Actually hook into Contentful preview API by changing contentWrapper
 export const prerender = "auto";
 
 export const load: PageServerLoad = async ({ params, locals }) => {

--- a/src/routes/projects/[slug]/+page.server.ts
+++ b/src/routes/projects/[slug]/+page.server.ts
@@ -12,7 +12,7 @@ export const load: PageServerLoad = async ({ params, locals }) => {
     {
       "fields.slug": params.slug,
     },
-    { preview: true }
+    { allowPreview: true }
   );
 
   if (projects.length === 0) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,5 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true
-  },
-  // Excludes merged with .svelte-kit/tsconfig.json
-  "exclude": [
-    "./scripts/*",
-    "./node_modules/**",
-    "./.svelte-kit/[!ambient.d.ts]**"
-  ]
+  }
 }


### PR DESCRIPTION
## Status:

:rocket: Ready

## Description

Fixes #75 

Uses Contentful preview API to access draft project entries if a secret query argument is supplied to a project page URL.

Only netlify deployment works for this.

## Todos

- [x] Add two new environment variables to Vercel and Netlify, `CONTENTFUL_PREVIEW_KEY` (Contentful preview API key) and `CONTENTFUL_PREVIEW_FLAG` (A secret value that does matter since I already added it to the repo, I can add it or just ask me for it).