### PR TITLE
Improve some member + project styles

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -117,6 +117,7 @@
       }
 
       h4,
+      li,
       p {
         font-size: 1rem;
       }

--- a/src/lib/components/Testimonial.svelte
+++ b/src/lib/components/Testimonial.svelte
@@ -109,6 +109,7 @@
   .right > img {
     height: 12rem;
     aspect-ratio: 1;
+    object-fit: cover;
     border-radius: 50%;
   }
 

--- a/src/lib/components/Testimonial.svelte
+++ b/src/lib/components/Testimonial.svelte
@@ -80,7 +80,6 @@
     padding: 0;
     margin: 0;
     text-align: justify;
-    text-justify: newspaper;
     font-size: 1rem;
   }
 

--- a/src/lib/components/projects/ProjectMember.svelte
+++ b/src/lib/components/projects/ProjectMember.svelte
@@ -27,5 +27,7 @@
     border-radius: 100%;
     margin-bottom: 10px;
     width: 100%;
+    aspect-ratio: 1;
+    object-fit: cover;
   }
 </style>

--- a/src/lib/utils/api.ts
+++ b/src/lib/utils/api.ts
@@ -78,7 +78,9 @@ export class ContentWrapper {
                       node.data.target.fields;
                     return `
                       <div class="column-center long-form-embed">
-                          <img src="https:${file.url}?w=1200" alt="${title}" />
+                          <img loading="lazy" src="https:${
+                            file.url
+                          }?w=1200" alt="${title}" />
                           ${
                             description !== undefined
                               ? `<span>${description}</span>`

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -49,7 +49,12 @@
   <p>{data.project.nonprofitDescription}</p>
 </Section>
 
-<Section id="project-description" longForm padding="40px">
+<Section
+  id="project-description"
+  longForm
+  padding="40px"
+  --accent-color={data.project.accentColor}
+>
   {@html data.project.fullDescription}
 </Section>
 
@@ -165,5 +170,9 @@
 
   :global(#project-description h2) {
     font-size: 1.2rem;
+  }
+
+  :global(#project-description li) {
+    text-decoration: underline var(--accent-color);
   }
 </style>


### PR DESCRIPTION
## Status:

:rocket: Ready

## Description

Makes all member images perfect circles on all pages, and fixes some font sizes on `<li>` elements. Also makes underlines in project pages colored with the project's accent color. I thought this was a nice way to make them stand out, and on the 7000 Languages project page (in preview rn), they use bullets + underlines in a unique way (shown below). I think standardizing some ways we organize content on the project pages with more flashy coloring + layout could be nice, and maybe this is a start? Open to reverting the underline color change.

I also set project page images to `loading="lazy"`, since some of those pages have tons of relatively high res images. None of them really show up above the fold anyways, so I thought this might be beneficial.

## Screenshots
<img width="791" alt="image" src="https://user-images.githubusercontent.com/23221268/210917060-99373f34-7148-46f5-9efa-e8d15c290f70.png">
