### PR TITLE
Fix Landing Banner Layout Shift

### DIFF
--- a/src/lib/components/DoubleBanner.svelte
+++ b/src/lib/components/DoubleBanner.svelte
@@ -3,7 +3,9 @@
   export let rightColor = "#fff";
 </script>
 
-<section class="row-center">
+<section
+  class={$$restProps.class ? `row-center ${$$restProps.class}` : "row-center"}
+>
   <div
     id="banner-left"
     class="banner column-center"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,11 @@
   export let data: PageData;
 </script>
 
-<DoubleBanner leftColor="var(--blue)" rightColor="var(--blue-darker)">
+<DoubleBanner
+  leftColor="var(--blue)"
+  rightColor="var(--blue-darker)"
+  class="landing"
+>
   <span slot="left">
     {#if data.info.homepageBannerText && data.info.homepageBannerUrl}
       <a class="banner" href={data.info.homepageBannerUrl}>
@@ -143,7 +147,7 @@
     object-position: left top;
   }
 
-  :global(#banner-right-content) {
+  :global(.landing #banner-right-content) {
     padding-right: 0 !important;
     padding-left: 10% !important;
   }


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready

## Description

Resolves the landing page banner image shifting when pre-fetching the stylesheet for project pages

## Original Behavior (Fixed by this PR)
https://user-images.githubusercontent.com/19193347/211181575-882499d1-0a7c-49b2-9a2a-124ee3955d22.mp4
