### PR TITLE
SvelteKit upgrade and Icon system change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,7 @@
       "name": "hack4impact-uiuc",
       "version": "0.0.1",
       "dependencies": {
-        "@svicons/boxicons-regular": "^0.1.3",
-        "@svicons/boxicons-solid": "^0.1.3",
+        "@iconify/svelte": "^3.1.0",
         "ackee-tracker": "^5.1.0",
         "contentful": "^9.1.5",
         "svelte-animated-details": "^1.0.1"
@@ -162,9 +161,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.7.tgz",
-      "integrity": "sha512-yhzDbiVcmq6T1/XEvdcJIVcXHdLjDJ5cQ0Dp9R9p9ERMBTeO1dR5tc8YYv8zwDeBw1xZm+Eo3MRo8cwclhBS0g==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+      "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
       "cpu": [
         "arm"
       ],
@@ -178,9 +177,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.7.tgz",
-      "integrity": "sha512-tYFw0lBJSEvLoGzzYh1kXuzoX1iPkbOk3O29VqzQb0HbOy7t/yw1hGkvwoJhXHwzQUPsShyYcTgRf6bDBcfnTw==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+      "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
       "cpu": [
         "arm64"
       ],
@@ -194,9 +193,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.7.tgz",
-      "integrity": "sha512-3P2OuTxwAtM3k/yEWTNUJRjMPG1ce8rXs51GTtvEC5z1j8fC1plHeVVczdeHECU7aM2/Buc0MwZ6ciM/zysnWg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+      "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
       "cpu": [
         "x64"
       ],
@@ -210,9 +209,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.7.tgz",
-      "integrity": "sha512-VUb9GK23z8jkosHU9yJNUgQpsfJn+7ZyBm6adi2Ec5/U241eR1tAn82QicnUzaFDaffeixiHwikjmnec/YXEZg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
+      "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
       "cpu": [
         "arm64"
       ],
@@ -226,9 +225,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.7.tgz",
-      "integrity": "sha512-duterlv3tit3HI9vhzMWnSVaB1B6YsXpFq1Ntd6Fou82BB1l4tucYy3FI9dHv3tvtDuS0NiGf/k6XsdBqPZ01w==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+      "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
       "cpu": [
         "x64"
       ],
@@ -242,9 +241,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.7.tgz",
-      "integrity": "sha512-9kkycpBFes/vhi7B7o0cf+q2WdJi+EpVzpVTqtWFNiutARWDFFLcB93J8PR1cG228sucsl3B+7Ts27izE6qiaQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+      "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
       "cpu": [
         "arm64"
       ],
@@ -258,9 +257,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.7.tgz",
-      "integrity": "sha512-5Ahf6jzWXJ4J2uh9dpy5DKOO+PeRUE/9DMys6VuYfwgQzd6n5+pVFm58L2Z2gRe611RX6SdydnNaiIKM3svY7g==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+      "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
       "cpu": [
         "x64"
       ],
@@ -274,9 +273,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.7.tgz",
-      "integrity": "sha512-QqJnyCfu5OF78Olt7JJSZ7OSv/B4Hf+ZJWp4kkq9xwMsgu7yWq3crIic8gGOpDYTqVKKMDAVDgRXy5Wd/nWZyQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+      "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
       "cpu": [
         "arm"
       ],
@@ -290,9 +289,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.7.tgz",
-      "integrity": "sha512-2wv0xYDskk2+MzIm/AEprDip39a23Chptc4mL7hsHg26P0gD8RUhzmDu0KCH2vMThUI1sChXXoK9uH0KYQKaDg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+      "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
       "cpu": [
         "arm64"
       ],
@@ -306,9 +305,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.7.tgz",
-      "integrity": "sha512-APVYbEilKbD5ptmKdnIcXej2/+GdV65TfTjxR2Uk8t1EsOk49t6HapZW6DS/Bwlvh5hDwtLapdSumIVNGxgqLg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+      "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
       "cpu": [
         "ia32"
       ],
@@ -322,9 +321,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.7.tgz",
-      "integrity": "sha512-5wPUAGclplQrAW7EFr3F84Y/d++7G0KykohaF4p54+iNWhUnMVU8Bh2sxiEOXUy4zKIdpHByMgJ5/Ko6QhtTUw==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+      "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
       "cpu": [
         "loong64"
       ],
@@ -338,9 +337,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.7.tgz",
-      "integrity": "sha512-hxzlXtWF6yWfkE/SMTscNiVqLOAn7fOuIF3q/kiZaXxftz1DhZW/HpnTmTTWrzrS7zJWQxHHT4QSxyAj33COmA==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+      "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
       "cpu": [
         "mips64el"
       ],
@@ -354,9 +353,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.7.tgz",
-      "integrity": "sha512-WM83Dac0LdXty5xPhlOuCD5Egfk1xLND/oRLYeB7Jb/tY4kzFSDgLlq91wYbHua/s03tQGA9iXvyjgymMw62Vw==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+      "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
       "cpu": [
         "ppc64"
       ],
@@ -370,9 +369,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.7.tgz",
-      "integrity": "sha512-3nkNnNg4Ax6MS/l8O8Ynq2lGEVJYyJ2EoY3PHjNJ4PuZ80EYLMrFTFZ4L/Hc16AxgtXKwmNP9TM0YKNiBzBiJQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+      "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
       "cpu": [
         "riscv64"
       ],
@@ -386,9 +385,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.7.tgz",
-      "integrity": "sha512-3SA/2VJuv0o1uD7zuqxEP+RrAyRxnkGddq0bwHQ98v1KNlzXD/JvxwTO3T6GM5RH6JUd29RTVQTOJfyzMkkppA==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+      "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
       "cpu": [
         "s390x"
       ],
@@ -402,9 +401,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.7.tgz",
-      "integrity": "sha512-xi/tbqCqvPIzU+zJVyrpz12xqciTAPMi2fXEWGnapZymoGhuL2GIWIRXg4O2v5BXaYA5TSaiKYE14L0QhUTuQg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+      "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
       "cpu": [
         "x64"
       ],
@@ -418,9 +417,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.7.tgz",
-      "integrity": "sha512-NUsYbq3B+JdNKn8SXkItFvdes9qTwEoS3aLALtiWciW/ystiCKM20Fgv9XQBOXfhUHyh5CLEeZDXzLOrwBXuCQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+      "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
       "cpu": [
         "x64"
       ],
@@ -434,9 +433,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.7.tgz",
-      "integrity": "sha512-qjwzsgeve9I8Tbsko2FEkdSk2iiezuNGFgipQxY/736NePXDaDZRodIejYGWOlbYXugdxb0nif5yvypH6lKBmA==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+      "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
       "cpu": [
         "x64"
       ],
@@ -450,9 +449,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.7.tgz",
-      "integrity": "sha512-mFWDz4RoBTzPphTCkM7Kc7Qpa0o/Z01acajR+Ai7LdfKgcP/C6jYOaKwv7nKzD0+MjOT20j7You9g4ozYy1dKQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+      "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
       "cpu": [
         "x64"
       ],
@@ -466,9 +465,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.7.tgz",
-      "integrity": "sha512-m39UmX19RvEIuC8sYZ0M+eQtdXw4IePDSZ78ZQmYyFaXY9krq4YzQCK2XWIJomNLtg4q+W5aXr8bW3AbqWNoVg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+      "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
       "cpu": [
         "arm64"
       ],
@@ -482,9 +481,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.7.tgz",
-      "integrity": "sha512-1cbzSEZA1fANwmT6rjJ4G1qQXHxCxGIcNYFYR9ctI82/prT38lnwSRZ0i5p/MVXksw9eMlHlet6pGu2/qkXFCg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+      "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
       "cpu": [
         "ia32"
       ],
@@ -498,9 +497,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.7.tgz",
-      "integrity": "sha512-QaQ8IH0JLacfGf5cf0HCCPnQuCTd/dAI257vXBgb/cccKGbH/6pVtI1gwhdAQ0Y48QSpTIFrh9etVyNdZY+zzw==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+      "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
       "cpu": [
         "x64"
       ],
@@ -511,6 +510,30 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.2.0.tgz",
+      "integrity": "sha512-gB8T4H4DEfX2IV9zGDJPOBgP1e/DbfCPDTtEqUMckpvzS1OYtva8JdFYBqMwYk7xAQ429WGF/UPqn8uQ//h2vQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.0.tgz",
+      "integrity": "sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -567,6 +590,25 @@
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "dev": true
+    },
+    "node_modules/@iconify/svelte": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/svelte/-/svelte-3.1.0.tgz",
+      "integrity": "sha512-G1w1dcO7eiD+JmQJNwNW4qnAn86oQxKLe1P/iAPjJ0qYYuF7Pb60TPrlcj4+2gu4SXe3a0Jrv++8YmceG+gX/g==",
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "svelte": ">=3"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -713,18 +755,6 @@
         "vite": "^4.0.0"
       }
     },
-    "node_modules/@sveltejs/kit/node_modules/magic-string": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.3.tgz",
@@ -758,16 +788,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@svicons/boxicons-regular": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@svicons/boxicons-regular/-/boxicons-regular-0.1.11.tgz",
-      "integrity": "sha512-WOfKj+6COf+JYyB52gQTLJ7kuI2A9jaAPawK6piiW6PbGTPJ+6P2b2M5gWB6d9b9zZV9QjTEHEZTlenwbrvZ+g=="
-    },
-    "node_modules/@svicons/boxicons-solid": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@svicons/boxicons-solid/-/boxicons-solid-0.1.11.tgz",
-      "integrity": "sha512-3OeLWmKIEqpP9t/PIdsH5rfN7bW833NGpm2wHjuVSVbfFtoAdhMpuF12oNCg1ko7DT0aaUIZeei6s2M3q4hqKQ=="
-    },
     "node_modules/@types/ackee-tracker": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/ackee-tracker/-/ackee-tracker-5.0.2.tgz",
@@ -792,12 +812,6 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
-    "node_modules/@types/node": {
-      "version": "18.11.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.16.tgz",
-      "integrity": "sha512-6T7P5bDkRhqRxrQtwj7vru+bWTpelgtcETAZEUSdq0YISKz8WKdoBukQLYQQ6DFHvU9JRsbFq0JH5C51X2ZdnA==",
-      "dev": true
-    },
     "node_modules/@types/pug": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.6.tgz",
@@ -805,12 +819,13 @@
       "dev": true
     },
     "node_modules/@types/sass": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
-      "integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
+      "integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
+      "deprecated": "This is a stub types definition. sass provides its own type definitions, so you do not need this installed.",
       "dev": true,
       "dependencies": {
-        "@types/node": "*"
+        "sass": "*"
       }
     },
     "node_modules/@types/semver": {
@@ -820,18 +835,19 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.1.tgz",
-      "integrity": "sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.55.0.tgz",
+      "integrity": "sha512-IZGc50rtbjk+xp5YQoJvmMPmJEYoC53SiKPXyqWfv15XoD2Y5Kju6zN0DwlmaGJp1Iw33JsWJcQ7nw0lGCGjVg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.46.1",
-        "@typescript-eslint/type-utils": "5.46.1",
-        "@typescript-eslint/utils": "5.46.1",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.55.0",
+        "@typescript-eslint/type-utils": "5.55.0",
+        "@typescript-eslint/utils": "5.55.0",
         "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
-        "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
@@ -853,14 +869,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.46.1.tgz",
-      "integrity": "sha512-RelQ5cGypPh4ySAtfIMBzBGyrNerQcmfA1oJvPj5f+H4jI59rl9xxpn4bonC0tQvUKOEN7eGBFWxFLK3Xepneg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.55.0.tgz",
+      "integrity": "sha512-ppvmeF7hvdhUUZWSd2EEWfzcFkjJzgNQzVST22nzg958CR+sphy8A6K7LXQZd6V75m1VKjp+J4g/PCEfSCmzhw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.46.1",
-        "@typescript-eslint/types": "5.46.1",
-        "@typescript-eslint/typescript-estree": "5.46.1",
+        "@typescript-eslint/scope-manager": "5.55.0",
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/typescript-estree": "5.55.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -880,13 +896,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
-      "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.55.0.tgz",
+      "integrity": "sha512-OK+cIO1ZGhJYNCL//a3ROpsd83psf4dUJ4j7pdNVzd5DmIk+ffkuUIX2vcZQbEW/IR41DYsfJTB19tpCboxQuw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.46.1",
-        "@typescript-eslint/visitor-keys": "5.46.1"
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/visitor-keys": "5.55.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -897,13 +913,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.46.1.tgz",
-      "integrity": "sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.55.0.tgz",
+      "integrity": "sha512-ObqxBgHIXj8rBNm0yh8oORFrICcJuZPZTqtAFh0oZQyr5DnAHZWfyw54RwpEEH+fD8suZaI0YxvWu5tYE/WswA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.46.1",
-        "@typescript-eslint/utils": "5.46.1",
+        "@typescript-eslint/typescript-estree": "5.55.0",
+        "@typescript-eslint/utils": "5.55.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -924,9 +940,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
-      "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.55.0.tgz",
+      "integrity": "sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -937,13 +953,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
-      "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.55.0.tgz",
+      "integrity": "sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.46.1",
-        "@typescript-eslint/visitor-keys": "5.46.1",
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/visitor-keys": "5.55.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -964,18 +980,18 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.46.1.tgz",
-      "integrity": "sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.55.0.tgz",
+      "integrity": "sha512-FkW+i2pQKcpDC3AY6DU54yl8Lfl14FVGYDgBTyGKB75cCwV3KpkpTMFi9d9j2WAJ4271LR2HeC5SEWF/CZmmfw==",
       "dev": true,
       "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.46.1",
-        "@typescript-eslint/types": "5.46.1",
-        "@typescript-eslint/typescript-estree": "5.46.1",
+        "@typescript-eslint/scope-manager": "5.55.0",
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/typescript-estree": "5.55.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
@@ -990,12 +1006,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
-      "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.55.0.tgz",
+      "integrity": "sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/types": "5.55.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -1277,9 +1293,9 @@
       }
     },
     "node_modules/clean-css": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.1.tgz",
-      "integrity": "sha512-lCr8OHhiWCTw4v8POJovCoh4T7I9U11yVsPjMWWnnMmp9ZowCxyad1Pathle/9HjaDp+fdQKjO9fQydE6RHTZg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
+      "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
       "dev": true,
       "dependencies": {
         "source-map": "~0.6.0"
@@ -1333,14 +1349,15 @@
       "dev": true
     },
     "node_modules/contentful": {
-      "version": "9.2.14",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-9.2.14.tgz",
-      "integrity": "sha512-HL//idmpr3g46Y2h8IpDCuMGlerp69P1gSXIgP3YqOyERsmdSrKm1ziGNSk/c902+yE0wc0Rrh1HlxGY1EtpQw==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-9.3.3.tgz",
+      "integrity": "sha512-tFfdVEstxhzr4kfRZzhv8V6fx43GSGkyvzoMdQ8KROF7vPXLwQSeTNE7rOjBEJFqKyE/oHZXZQkmkvuezIImlg==",
       "hasInstallScript": true,
       "dependencies": {
+        "@contentful/rich-text-types": "^16.0.2",
         "axios": "^0.27.0",
         "contentful-resolve-response": "^1.3.12",
-        "contentful-sdk-core": "^7.0.4",
+        "contentful-sdk-core": "^7.0.5",
         "fast-copy": "^2.1.7",
         "json-stringify-safe": "^5.0.1"
       },
@@ -1349,9 +1366,9 @@
       }
     },
     "node_modules/contentful-resolve-response": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.4.0.tgz",
-      "integrity": "sha512-r5Ljl8BpqDQ/aI7bWidG0Rzzge5E4Q5fNjBoiufirUT7TZOdn4TvWfBB/k3LXWfwhRcauC6dnU9696i6LCY4lg==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.6.5.tgz",
+      "integrity": "sha512-3uH6tI8rmBnDDtzyD4fZg3aecuYYCMe0q24/sdgQELvsza+OAiqrxzyiXJIAs7c5exIp5bbLwMtZLW/33OGvxg==",
       "dependencies": {
         "fast-copy": "^2.1.7"
       },
@@ -1360,9 +1377,9 @@
       }
     },
     "node_modules/contentful-sdk-core": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.4.tgz",
-      "integrity": "sha512-HwYdXmTsVh9rJOq+TA8CsY+vt6ivqkyJZpiEyVboZKIXAa83QmeVLAeBxK75+IiI9KpaPz7LCjVBXTGoTrhV7A==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.6.tgz",
+      "integrity": "sha512-xG4+a4p7VGCuxxUWh8t3O3V6gEcPP/aSE/KkvPRMYkm8PbxWYTAYG3c5pn5lmtj1QKcsY7yjiLWRXtP4qzem3Q==",
       "dependencies": {
         "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
@@ -1372,6 +1389,14 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/contentful/node_modules/@contentful/rich-text-types": {
+      "version": "16.0.2",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.0.2.tgz",
+      "integrity": "sha512-ovbmCKQjlyGek4NuABoqDesC3FBV3e5jPMMdtT2mpOy9ia31MKO0NSFMRGZu7Q+veZzmDMja8S1i/XeFCUT9Pw==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/cookie": {
@@ -1511,9 +1536,9 @@
       "dev": true
     },
     "node_modules/esbuild": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.7.tgz",
-      "integrity": "sha512-P6OBFYFSQOGzfApqCeYKqfKRRbCIRsdppTXFo4aAvtiW3o8TTyiIplBvHJI171saPAiy3WlawJHCveJVIOIx1A==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
+      "integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -1523,28 +1548,28 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.16.7",
-        "@esbuild/android-arm64": "0.16.7",
-        "@esbuild/android-x64": "0.16.7",
-        "@esbuild/darwin-arm64": "0.16.7",
-        "@esbuild/darwin-x64": "0.16.7",
-        "@esbuild/freebsd-arm64": "0.16.7",
-        "@esbuild/freebsd-x64": "0.16.7",
-        "@esbuild/linux-arm": "0.16.7",
-        "@esbuild/linux-arm64": "0.16.7",
-        "@esbuild/linux-ia32": "0.16.7",
-        "@esbuild/linux-loong64": "0.16.7",
-        "@esbuild/linux-mips64el": "0.16.7",
-        "@esbuild/linux-ppc64": "0.16.7",
-        "@esbuild/linux-riscv64": "0.16.7",
-        "@esbuild/linux-s390x": "0.16.7",
-        "@esbuild/linux-x64": "0.16.7",
-        "@esbuild/netbsd-x64": "0.16.7",
-        "@esbuild/openbsd-x64": "0.16.7",
-        "@esbuild/sunos-x64": "0.16.7",
-        "@esbuild/win32-arm64": "0.16.7",
-        "@esbuild/win32-ia32": "0.16.7",
-        "@esbuild/win32-x64": "0.16.7"
+        "@esbuild/android-arm": "0.16.17",
+        "@esbuild/android-arm64": "0.16.17",
+        "@esbuild/android-x64": "0.16.17",
+        "@esbuild/darwin-arm64": "0.16.17",
+        "@esbuild/darwin-x64": "0.16.17",
+        "@esbuild/freebsd-arm64": "0.16.17",
+        "@esbuild/freebsd-x64": "0.16.17",
+        "@esbuild/linux-arm": "0.16.17",
+        "@esbuild/linux-arm64": "0.16.17",
+        "@esbuild/linux-ia32": "0.16.17",
+        "@esbuild/linux-loong64": "0.16.17",
+        "@esbuild/linux-mips64el": "0.16.17",
+        "@esbuild/linux-ppc64": "0.16.17",
+        "@esbuild/linux-riscv64": "0.16.17",
+        "@esbuild/linux-s390x": "0.16.17",
+        "@esbuild/linux-x64": "0.16.17",
+        "@esbuild/netbsd-x64": "0.16.17",
+        "@esbuild/openbsd-x64": "0.16.17",
+        "@esbuild/sunos-x64": "0.16.17",
+        "@esbuild/win32-arm64": "0.16.17",
+        "@esbuild/win32-ia32": "0.16.17",
+        "@esbuild/win32-x64": "0.16.17"
       }
     },
     "node_modules/escape-html": {
@@ -1623,9 +1648,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
+      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -1661,42 +1686,6 @@
       }
     },
     "node_modules/eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "dependencies": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "engines": {
-        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mysticatea"
-      },
-      "peerDependencies": {
-        "eslint": ">=5"
-      }
-    },
-    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
-      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
       "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
@@ -1711,13 +1700,22 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
-    "node_modules/eslint/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+    "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -1781,9 +1779,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -1880,9 +1878,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -1995,9 +1993,9 @@
       "dev": true
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -2040,9 +2038,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.19.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
-      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2090,6 +2088,12 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
     "node_modules/has": {
@@ -2154,13 +2158,19 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
-      "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immutable": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -2374,9 +2384,9 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.13"
@@ -2460,9 +2470,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2548,9 +2558,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2681,9 +2691,9 @@
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "node_modules/postcss": {
-      "version": "8.4.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
       "dev": true,
       "funding": [
         {
@@ -2714,9 +2724,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -2748,18 +2758,18 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+      "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -2884,9 +2894,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.4.tgz",
-      "integrity": "sha512-jN9rx3k5pfg9H9al0r0y1EYKSeiRANZRYX32SuNXAnKzh6cVyf4LZVto1KAuDnbHT03E1CpsgqDKaqQ8FZtgxw==",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.19.1.tgz",
+      "integrity": "sha512-lAbrdN7neYCg/8WaoWn/ckzCtz+jr70GFfYdlf50OF7387HTg+wiuiqJRFYawwSPpqfqDNYqK7smY/ks2iAudg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2956,6 +2966,23 @@
       },
       "bin": {
         "rimraf": "bin.js"
+      }
+    },
+    "node_modules/sass": {
+      "version": "1.59.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.59.2.tgz",
+      "integrity": "sha512-jJyO6SmbzkJexF8MUorHx5tAilcgabioYxT/BHbY4+OvoqmbHxsYlrjZ8Adhqcgl6Zqwie0TgMXLCAmPFxXOuw==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/semver": {
@@ -3054,18 +3081,18 @@
       }
     },
     "node_modules/sorcery": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
-      "integrity": "sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.11.0.tgz",
+      "integrity": "sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.14",
         "buffer-crc32": "^0.2.5",
         "minimist": "^1.2.0",
-        "sander": "^0.5.0",
-        "sourcemap-codec": "^1.3.0"
+        "sander": "^0.5.0"
       },
       "bin": {
-        "sorcery": "bin/index.js"
+        "sorcery": "bin/sorcery"
       }
     },
     "node_modules/source-map": {
@@ -3095,13 +3122,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -3193,10 +3213,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.0.tgz",
-      "integrity": "sha512-uGu2FVMlOuey4JoKHKrpZFkoYyj0VLjJdz47zX5+gVK5odxHM40RVhar9/iK2YFRVxvfg9FkhfVlR0sjeIrOiA==",
-      "dev": true,
+      "version": "3.56.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.56.0.tgz",
+      "integrity": "sha512-LvXiJbjdvJKwB/0CQyYpDX0q+hFqCyWmybzC2G6eK1tJJA/RSRCytTfNmjHv+RHlLuA70vWG7nXp6gbeErYvRA==",
       "engines": {
         "node": ">= 8"
       }
@@ -3207,9 +3226,9 @@
       "integrity": "sha512-solG1K+4gVwPQuHLxQvxr9JSZnLWD4ANcTuH3vGe2ors+mZQRW+doKGhLvI8twlel/5zkVW1CqqMCeF25+NKNg=="
     },
     "node_modules/svelte-check": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.1.2.tgz",
-      "integrity": "sha512-8nIPXPe8TiUiWPCAoegU+l1NaL5DKLnN6+H1dJqbjkD6IkhpDTMj2q8Z88lhCOsq1F3E7st5/Vn7eGeGkSo/aA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.1.4.tgz",
+      "integrity": "sha512-25Lb46ZS4IK/XpBMe4IBMrtYf23V8alqBX+szXoccb7uM0D2Wqq5rMRzYBONZnFVuU1bQG3R50lyIT5eRewv2g==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.17",
@@ -3241,9 +3260,9 @@
       }
     },
     "node_modules/svelte-preprocess": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.0.tgz",
-      "integrity": "sha512-q7lpa7i2FBu8Pa+G0MmuQQWETBwCKgsGmuq1Sf6n8q4uaG9ZLcLP0Y+etC6bF4sE6EbLxfiI38zV6RfPe3RSfg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.1.tgz",
+      "integrity": "sha512-0HXyhCoc9rsW4zGOgtInylC6qj259E1hpFnJMJWTf+aIfeqh4O/QHT31KT2hvPEqQfdjmqBR/kO2JDkkciBLrQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3251,7 +3270,7 @@
         "@types/sass": "^1.43.1",
         "detect-indent": "^6.1.0",
         "magic-string": "^0.27.0",
-        "sorcery": "^0.10.0",
+        "sorcery": "^0.11.0",
         "strip-indent": "^3.0.0"
       },
       "engines": {
@@ -3303,6 +3322,18 @@
         }
       }
     },
+    "node_modules/svelte-preprocess/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/table": {
       "version": "6.8.1",
       "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
@@ -3320,9 +3351,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -3342,9 +3373,9 @@
       "dev": true
     },
     "node_modules/terser": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+      "version": "5.16.6",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.6.tgz",
+      "integrity": "sha512-IBZ+ZQIA9sMaXmRZCUMDjNH0D5AQQfdn4WUjHL0+1lF4TP1IHRJbrhb6fNaXWikrYQTSkb7SLxkeXAiy1p7mbg==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -3360,9 +3391,9 @@
       }
     },
     "node_modules/terser/node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -3415,9 +3446,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "dev": true
     },
     "node_modules/tsutils": {
@@ -3466,9 +3497,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3506,15 +3537,15 @@
       "dev": true
     },
     "node_modules/vite": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.1.tgz",
-      "integrity": "sha512-kZQPzbDau35iWOhy3CpkrRC7It+HIHtulAzBhMqzGHKRf/4+vmh8rPDDdv98SWQrFWo6//3ozwsRmwQIPZsK9g==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.1.4.tgz",
+      "integrity": "sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==",
       "dev": true,
       "dependencies": {
-        "esbuild": "^0.16.3",
-        "postcss": "^8.4.20",
+        "esbuild": "^0.16.14",
+        "postcss": "^8.4.21",
         "resolve": "^1.22.1",
-        "rollup": "^3.7.0"
+        "rollup": "^3.10.0"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3707,158 +3738,173 @@
       "dev": true
     },
     "@esbuild/android-arm": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.7.tgz",
-      "integrity": "sha512-yhzDbiVcmq6T1/XEvdcJIVcXHdLjDJ5cQ0Dp9R9p9ERMBTeO1dR5tc8YYv8zwDeBw1xZm+Eo3MRo8cwclhBS0g==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+      "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/android-arm64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.7.tgz",
-      "integrity": "sha512-tYFw0lBJSEvLoGzzYh1kXuzoX1iPkbOk3O29VqzQb0HbOy7t/yw1hGkvwoJhXHwzQUPsShyYcTgRf6bDBcfnTw==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+      "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/android-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.7.tgz",
-      "integrity": "sha512-3P2OuTxwAtM3k/yEWTNUJRjMPG1ce8rXs51GTtvEC5z1j8fC1plHeVVczdeHECU7aM2/Buc0MwZ6ciM/zysnWg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+      "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/darwin-arm64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.7.tgz",
-      "integrity": "sha512-VUb9GK23z8jkosHU9yJNUgQpsfJn+7ZyBm6adi2Ec5/U241eR1tAn82QicnUzaFDaffeixiHwikjmnec/YXEZg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
+      "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
       "dev": true,
       "optional": true
     },
     "@esbuild/darwin-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.7.tgz",
-      "integrity": "sha512-duterlv3tit3HI9vhzMWnSVaB1B6YsXpFq1Ntd6Fou82BB1l4tucYy3FI9dHv3tvtDuS0NiGf/k6XsdBqPZ01w==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+      "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-arm64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.7.tgz",
-      "integrity": "sha512-9kkycpBFes/vhi7B7o0cf+q2WdJi+EpVzpVTqtWFNiutARWDFFLcB93J8PR1cG228sucsl3B+7Ts27izE6qiaQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+      "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.7.tgz",
-      "integrity": "sha512-5Ahf6jzWXJ4J2uh9dpy5DKOO+PeRUE/9DMys6VuYfwgQzd6n5+pVFm58L2Z2gRe611RX6SdydnNaiIKM3svY7g==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+      "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.7.tgz",
-      "integrity": "sha512-QqJnyCfu5OF78Olt7JJSZ7OSv/B4Hf+ZJWp4kkq9xwMsgu7yWq3crIic8gGOpDYTqVKKMDAVDgRXy5Wd/nWZyQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+      "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.7.tgz",
-      "integrity": "sha512-2wv0xYDskk2+MzIm/AEprDip39a23Chptc4mL7hsHg26P0gD8RUhzmDu0KCH2vMThUI1sChXXoK9uH0KYQKaDg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+      "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-ia32": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.7.tgz",
-      "integrity": "sha512-APVYbEilKbD5ptmKdnIcXej2/+GdV65TfTjxR2Uk8t1EsOk49t6HapZW6DS/Bwlvh5hDwtLapdSumIVNGxgqLg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+      "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-loong64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.7.tgz",
-      "integrity": "sha512-5wPUAGclplQrAW7EFr3F84Y/d++7G0KykohaF4p54+iNWhUnMVU8Bh2sxiEOXUy4zKIdpHByMgJ5/Ko6QhtTUw==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+      "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-mips64el": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.7.tgz",
-      "integrity": "sha512-hxzlXtWF6yWfkE/SMTscNiVqLOAn7fOuIF3q/kiZaXxftz1DhZW/HpnTmTTWrzrS7zJWQxHHT4QSxyAj33COmA==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+      "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-ppc64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.7.tgz",
-      "integrity": "sha512-WM83Dac0LdXty5xPhlOuCD5Egfk1xLND/oRLYeB7Jb/tY4kzFSDgLlq91wYbHua/s03tQGA9iXvyjgymMw62Vw==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+      "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-riscv64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.7.tgz",
-      "integrity": "sha512-3nkNnNg4Ax6MS/l8O8Ynq2lGEVJYyJ2EoY3PHjNJ4PuZ80EYLMrFTFZ4L/Hc16AxgtXKwmNP9TM0YKNiBzBiJQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+      "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-s390x": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.7.tgz",
-      "integrity": "sha512-3SA/2VJuv0o1uD7zuqxEP+RrAyRxnkGddq0bwHQ98v1KNlzXD/JvxwTO3T6GM5RH6JUd29RTVQTOJfyzMkkppA==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+      "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.7.tgz",
-      "integrity": "sha512-xi/tbqCqvPIzU+zJVyrpz12xqciTAPMi2fXEWGnapZymoGhuL2GIWIRXg4O2v5BXaYA5TSaiKYE14L0QhUTuQg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+      "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/netbsd-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.7.tgz",
-      "integrity": "sha512-NUsYbq3B+JdNKn8SXkItFvdes9qTwEoS3aLALtiWciW/ystiCKM20Fgv9XQBOXfhUHyh5CLEeZDXzLOrwBXuCQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+      "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/openbsd-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.7.tgz",
-      "integrity": "sha512-qjwzsgeve9I8Tbsko2FEkdSk2iiezuNGFgipQxY/736NePXDaDZRodIejYGWOlbYXugdxb0nif5yvypH6lKBmA==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+      "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/sunos-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.7.tgz",
-      "integrity": "sha512-mFWDz4RoBTzPphTCkM7Kc7Qpa0o/Z01acajR+Ai7LdfKgcP/C6jYOaKwv7nKzD0+MjOT20j7You9g4ozYy1dKQ==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+      "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-arm64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.7.tgz",
-      "integrity": "sha512-m39UmX19RvEIuC8sYZ0M+eQtdXw4IePDSZ78ZQmYyFaXY9krq4YzQCK2XWIJomNLtg4q+W5aXr8bW3AbqWNoVg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+      "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-ia32": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.7.tgz",
-      "integrity": "sha512-1cbzSEZA1fANwmT6rjJ4G1qQXHxCxGIcNYFYR9ctI82/prT38lnwSRZ0i5p/MVXksw9eMlHlet6pGu2/qkXFCg==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+      "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-x64": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.7.tgz",
-      "integrity": "sha512-QaQ8IH0JLacfGf5cf0HCCPnQuCTd/dAI257vXBgb/cccKGbH/6pVtI1gwhdAQ0Y48QSpTIFrh9etVyNdZY+zzw==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+      "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
       "dev": true,
       "optional": true
+    },
+    "@eslint-community/eslint-utils": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.2.0.tgz",
+      "integrity": "sha512-gB8T4H4DEfX2IV9zGDJPOBgP1e/DbfCPDTtEqUMckpvzS1OYtva8JdFYBqMwYk7xAQ429WGF/UPqn8uQ//h2vQ==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^3.3.0"
+      }
+    },
+    "@eslint-community/regexpp": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.4.0.tgz",
+      "integrity": "sha512-A9983Q0LnDGdLPjxyXQ00sbV+K+O+ko2Dr+CZigbHWtX9pNfxlaBkMR8X1CztI73zuEyEBXTVjx7CE+/VSwDiQ==",
+      "dev": true
     },
     "@eslint/eslintrc": {
       "version": "0.4.3",
@@ -3907,6 +3953,19 @@
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "dev": true
+    },
+    "@iconify/svelte": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/svelte/-/svelte-3.1.0.tgz",
+      "integrity": "sha512-G1w1dcO7eiD+JmQJNwNW4qnAn86oQxKLe1P/iAPjJ0qYYuF7Pb60TPrlcj4+2gu4SXe3a0Jrv++8YmceG+gX/g==",
+      "requires": {
+        "@iconify/types": "^2.0.0"
+      }
+    },
+    "@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -4019,17 +4078,6 @@
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
         "undici": "5.20.0"
-      },
-      "dependencies": {
-        "magic-string": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-          "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
-          "dev": true,
-          "requires": {
-            "@jridgewell/sourcemap-codec": "^1.4.13"
-          }
-        }
       }
     },
     "@sveltejs/vite-plugin-svelte": {
@@ -4057,16 +4105,6 @@
         }
       }
     },
-    "@svicons/boxicons-regular": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@svicons/boxicons-regular/-/boxicons-regular-0.1.11.tgz",
-      "integrity": "sha512-WOfKj+6COf+JYyB52gQTLJ7kuI2A9jaAPawK6piiW6PbGTPJ+6P2b2M5gWB6d9b9zZV9QjTEHEZTlenwbrvZ+g=="
-    },
-    "@svicons/boxicons-solid": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@svicons/boxicons-solid/-/boxicons-solid-0.1.11.tgz",
-      "integrity": "sha512-3OeLWmKIEqpP9t/PIdsH5rfN7bW833NGpm2wHjuVSVbfFtoAdhMpuF12oNCg1ko7DT0aaUIZeei6s2M3q4hqKQ=="
-    },
     "@types/ackee-tracker": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@types/ackee-tracker/-/ackee-tracker-5.0.2.tgz",
@@ -4091,12 +4129,6 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
       "dev": true
     },
-    "@types/node": {
-      "version": "18.11.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.16.tgz",
-      "integrity": "sha512-6T7P5bDkRhqRxrQtwj7vru+bWTpelgtcETAZEUSdq0YISKz8WKdoBukQLYQQ6DFHvU9JRsbFq0JH5C51X2ZdnA==",
-      "dev": true
-    },
     "@types/pug": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.6.tgz",
@@ -4104,12 +4136,12 @@
       "dev": true
     },
     "@types/sass": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.43.1.tgz",
-      "integrity": "sha512-BPdoIt1lfJ6B7rw35ncdwBZrAssjcwzI5LByIrYs+tpXlj/CAkuVdRsgZDdP4lq5EjyWzwxZCqAoFyHKFwp32g==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@types/sass/-/sass-1.45.0.tgz",
+      "integrity": "sha512-jn7qwGFmJHwUSphV8zZneO3GmtlgLsmhs/LQyVvQbIIa+fzGMUiHI4HXJZL3FT8MJmgXWbLGiVVY7ElvHq6vDA==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "sass": "*"
       }
     },
     "@types/semver": {
@@ -4119,70 +4151,71 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.46.1.tgz",
-      "integrity": "sha512-YpzNv3aayRBwjs4J3oz65eVLXc9xx0PDbIRisHj+dYhvBn02MjYOD96P8YGiWEIFBrojaUjxvkaUpakD82phsA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.55.0.tgz",
+      "integrity": "sha512-IZGc50rtbjk+xp5YQoJvmMPmJEYoC53SiKPXyqWfv15XoD2Y5Kju6zN0DwlmaGJp1Iw33JsWJcQ7nw0lGCGjVg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.46.1",
-        "@typescript-eslint/type-utils": "5.46.1",
-        "@typescript-eslint/utils": "5.46.1",
+        "@eslint-community/regexpp": "^4.4.0",
+        "@typescript-eslint/scope-manager": "5.55.0",
+        "@typescript-eslint/type-utils": "5.55.0",
+        "@typescript-eslint/utils": "5.55.0",
         "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
-        "regexpp": "^3.2.0",
         "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.46.1.tgz",
-      "integrity": "sha512-RelQ5cGypPh4ySAtfIMBzBGyrNerQcmfA1oJvPj5f+H4jI59rl9xxpn4bonC0tQvUKOEN7eGBFWxFLK3Xepneg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.55.0.tgz",
+      "integrity": "sha512-ppvmeF7hvdhUUZWSd2EEWfzcFkjJzgNQzVST22nzg958CR+sphy8A6K7LXQZd6V75m1VKjp+J4g/PCEfSCmzhw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.46.1",
-        "@typescript-eslint/types": "5.46.1",
-        "@typescript-eslint/typescript-estree": "5.46.1",
+        "@typescript-eslint/scope-manager": "5.55.0",
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/typescript-estree": "5.55.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.46.1.tgz",
-      "integrity": "sha512-iOChVivo4jpwUdrJZyXSMrEIM/PvsbbDOX1y3UCKjSgWn+W89skxWaYXACQfxmIGhPVpRWK/VWPYc+bad6smIA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.55.0.tgz",
+      "integrity": "sha512-OK+cIO1ZGhJYNCL//a3ROpsd83psf4dUJ4j7pdNVzd5DmIk+ffkuUIX2vcZQbEW/IR41DYsfJTB19tpCboxQuw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.46.1",
-        "@typescript-eslint/visitor-keys": "5.46.1"
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/visitor-keys": "5.55.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.46.1.tgz",
-      "integrity": "sha512-V/zMyfI+jDmL1ADxfDxjZ0EMbtiVqj8LUGPAGyBkXXStWmCUErMpW873zEHsyguWCuq2iN4BrlWUkmuVj84yng==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.55.0.tgz",
+      "integrity": "sha512-ObqxBgHIXj8rBNm0yh8oORFrICcJuZPZTqtAFh0oZQyr5DnAHZWfyw54RwpEEH+fD8suZaI0YxvWu5tYE/WswA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.46.1",
-        "@typescript-eslint/utils": "5.46.1",
+        "@typescript-eslint/typescript-estree": "5.55.0",
+        "@typescript-eslint/utils": "5.55.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.46.1.tgz",
-      "integrity": "sha512-Z5pvlCaZgU+93ryiYUwGwLl9AQVB/PQ1TsJ9NZ/gHzZjN7g9IAn6RSDkpCV8hqTwAiaj6fmCcKSQeBPlIpW28w==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.55.0.tgz",
+      "integrity": "sha512-M4iRh4AG1ChrOL6Y+mETEKGeDnT7Sparn6fhZ5LtVJF1909D5O4uqK+C5NPbLmpfZ0XIIxCdwzKiijpZUOvOug==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.46.1.tgz",
-      "integrity": "sha512-j9W4t67QiNp90kh5Nbr1w92wzt+toiIsaVPnEblB2Ih2U9fqBTyqV9T3pYWZBRt6QoMh/zVWP59EpuCjc4VRBg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.55.0.tgz",
+      "integrity": "sha512-I7X4A9ovA8gdpWMpr7b1BN9eEbvlEtWhQvpxp/yogt48fy9Lj3iE3ild/1H3jKBBIYj5YYJmS2+9ystVhC7eaQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.46.1",
-        "@typescript-eslint/visitor-keys": "5.46.1",
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/visitor-keys": "5.55.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -4191,28 +4224,28 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.46.1.tgz",
-      "integrity": "sha512-RBdBAGv3oEpFojaCYT4Ghn4775pdjvwfDOfQ2P6qzNVgQOVrnSPe5/Pb88kv7xzYQjoio0eKHKB9GJ16ieSxvA==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.55.0.tgz",
+      "integrity": "sha512-FkW+i2pQKcpDC3AY6DU54yl8Lfl14FVGYDgBTyGKB75cCwV3KpkpTMFi9d9j2WAJ4271LR2HeC5SEWF/CZmmfw==",
       "dev": true,
       "requires": {
+        "@eslint-community/eslint-utils": "^4.2.0",
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.46.1",
-        "@typescript-eslint/types": "5.46.1",
-        "@typescript-eslint/typescript-estree": "5.46.1",
+        "@typescript-eslint/scope-manager": "5.55.0",
+        "@typescript-eslint/types": "5.55.0",
+        "@typescript-eslint/typescript-estree": "5.55.0",
         "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.46.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.46.1.tgz",
-      "integrity": "sha512-jczZ9noovXwy59KjRTk1OftT78pwygdcmCuBf8yMoWt/8O8l+6x2LSEze0E4TeepXK4MezW3zGSyoDRZK7Y9cg==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.55.0.tgz",
+      "integrity": "sha512-q2dlHHwWgirKh1D3acnuApXG+VNXpEY5/AwRxDVuEQpxWaB0jCDe0jFMVMALJ3ebSfuOVE8/rMS+9ZOYGg1GWw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.46.1",
+        "@typescript-eslint/types": "5.55.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -4419,9 +4452,9 @@
       }
     },
     "clean-css": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.1.tgz",
-      "integrity": "sha512-lCr8OHhiWCTw4v8POJovCoh4T7I9U11yVsPjMWWnnMmp9ZowCxyad1Pathle/9HjaDp+fdQKjO9fQydE6RHTZg==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.2.tgz",
+      "integrity": "sha512-JVJbM+f3d3Q704rF4bqQ5UUyTtuJ0JRKNbTKVEeujCCBoMdkEi+V+e8oktO9qGQNSvHrFTM6JZRXrUvGR1czww==",
       "dev": true,
       "requires": {
         "source-map": "~0.6.0"
@@ -4463,29 +4496,37 @@
       "dev": true
     },
     "contentful": {
-      "version": "9.2.14",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-9.2.14.tgz",
-      "integrity": "sha512-HL//idmpr3g46Y2h8IpDCuMGlerp69P1gSXIgP3YqOyERsmdSrKm1ziGNSk/c902+yE0wc0Rrh1HlxGY1EtpQw==",
+      "version": "9.3.3",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-9.3.3.tgz",
+      "integrity": "sha512-tFfdVEstxhzr4kfRZzhv8V6fx43GSGkyvzoMdQ8KROF7vPXLwQSeTNE7rOjBEJFqKyE/oHZXZQkmkvuezIImlg==",
       "requires": {
+        "@contentful/rich-text-types": "^16.0.2",
         "axios": "^0.27.0",
         "contentful-resolve-response": "^1.3.12",
-        "contentful-sdk-core": "^7.0.4",
+        "contentful-sdk-core": "^7.0.5",
         "fast-copy": "^2.1.7",
         "json-stringify-safe": "^5.0.1"
+      },
+      "dependencies": {
+        "@contentful/rich-text-types": {
+          "version": "16.0.2",
+          "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.0.2.tgz",
+          "integrity": "sha512-ovbmCKQjlyGek4NuABoqDesC3FBV3e5jPMMdtT2mpOy9ia31MKO0NSFMRGZu7Q+veZzmDMja8S1i/XeFCUT9Pw=="
+        }
       }
     },
     "contentful-resolve-response": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.4.0.tgz",
-      "integrity": "sha512-r5Ljl8BpqDQ/aI7bWidG0Rzzge5E4Q5fNjBoiufirUT7TZOdn4TvWfBB/k3LXWfwhRcauC6dnU9696i6LCY4lg==",
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.6.5.tgz",
+      "integrity": "sha512-3uH6tI8rmBnDDtzyD4fZg3aecuYYCMe0q24/sdgQELvsza+OAiqrxzyiXJIAs7c5exIp5bbLwMtZLW/33OGvxg==",
       "requires": {
         "fast-copy": "^2.1.7"
       }
     },
     "contentful-sdk-core": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.4.tgz",
-      "integrity": "sha512-HwYdXmTsVh9rJOq+TA8CsY+vt6ivqkyJZpiEyVboZKIXAa83QmeVLAeBxK75+IiI9KpaPz7LCjVBXTGoTrhV7A==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.6.tgz",
+      "integrity": "sha512-xG4+a4p7VGCuxxUWh8t3O3V6gEcPP/aSE/KkvPRMYkm8PbxWYTAYG3c5pn5lmtj1QKcsY7yjiLWRXtP4qzem3Q==",
       "requires": {
         "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
@@ -4599,33 +4640,33 @@
       "dev": true
     },
     "esbuild": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.7.tgz",
-      "integrity": "sha512-P6OBFYFSQOGzfApqCeYKqfKRRbCIRsdppTXFo4aAvtiW3o8TTyiIplBvHJI171saPAiy3WlawJHCveJVIOIx1A==",
+      "version": "0.16.17",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
+      "integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
       "dev": true,
       "requires": {
-        "@esbuild/android-arm": "0.16.7",
-        "@esbuild/android-arm64": "0.16.7",
-        "@esbuild/android-x64": "0.16.7",
-        "@esbuild/darwin-arm64": "0.16.7",
-        "@esbuild/darwin-x64": "0.16.7",
-        "@esbuild/freebsd-arm64": "0.16.7",
-        "@esbuild/freebsd-x64": "0.16.7",
-        "@esbuild/linux-arm": "0.16.7",
-        "@esbuild/linux-arm64": "0.16.7",
-        "@esbuild/linux-ia32": "0.16.7",
-        "@esbuild/linux-loong64": "0.16.7",
-        "@esbuild/linux-mips64el": "0.16.7",
-        "@esbuild/linux-ppc64": "0.16.7",
-        "@esbuild/linux-riscv64": "0.16.7",
-        "@esbuild/linux-s390x": "0.16.7",
-        "@esbuild/linux-x64": "0.16.7",
-        "@esbuild/netbsd-x64": "0.16.7",
-        "@esbuild/openbsd-x64": "0.16.7",
-        "@esbuild/sunos-x64": "0.16.7",
-        "@esbuild/win32-arm64": "0.16.7",
-        "@esbuild/win32-ia32": "0.16.7",
-        "@esbuild/win32-x64": "0.16.7"
+        "@esbuild/android-arm": "0.16.17",
+        "@esbuild/android-arm64": "0.16.17",
+        "@esbuild/android-x64": "0.16.17",
+        "@esbuild/darwin-arm64": "0.16.17",
+        "@esbuild/darwin-x64": "0.16.17",
+        "@esbuild/freebsd-arm64": "0.16.17",
+        "@esbuild/freebsd-x64": "0.16.17",
+        "@esbuild/linux-arm": "0.16.17",
+        "@esbuild/linux-arm64": "0.16.17",
+        "@esbuild/linux-ia32": "0.16.17",
+        "@esbuild/linux-loong64": "0.16.17",
+        "@esbuild/linux-mips64el": "0.16.17",
+        "@esbuild/linux-ppc64": "0.16.17",
+        "@esbuild/linux-riscv64": "0.16.17",
+        "@esbuild/linux-s390x": "0.16.17",
+        "@esbuild/linux-x64": "0.16.17",
+        "@esbuild/netbsd-x64": "0.16.17",
+        "@esbuild/openbsd-x64": "0.16.17",
+        "@esbuild/sunos-x64": "0.16.17",
+        "@esbuild/win32-arm64": "0.16.17",
+        "@esbuild/win32-ia32": "0.16.17",
+        "@esbuild/win32-x64": "0.16.17"
       }
     },
     "escape-html": {
@@ -4688,23 +4729,6 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          },
-          "dependencies": {
-            "eslint-visitor-keys": {
-              "version": "1.3.0",
-              "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-              "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-              "dev": true
-            }
-          }
-        },
         "eslint-visitor-keys": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
@@ -4720,9 +4744,9 @@
       }
     },
     "eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
+      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
       "dev": true,
       "requires": {}
     },
@@ -4744,18 +4768,18 @@
       }
     },
     "eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^2.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
           "dev": true
         }
       }
@@ -4798,9 +4822,9 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
-      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
       "dev": true,
       "requires": {
         "estraverse": "^5.1.0"
@@ -4880,9 +4904,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -4962,9 +4986,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
-      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.0.tgz",
+      "integrity": "sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==",
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -4995,9 +5019,9 @@
       }
     },
     "globals": {
-      "version": "13.19.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
-      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -5033,6 +5057,12 @@
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
       "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
+      "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
     "has": {
@@ -5076,9 +5106,15 @@
       }
     },
     "ignore": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.1.tgz",
-      "integrity": "sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+      "dev": true
+    },
+    "immutable": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+      "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
       "dev": true
     },
     "import-fresh": {
@@ -5254,9 +5290,9 @@
       }
     },
     "magic-string": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
-      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
       "dev": true,
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.4.13"
@@ -5313,9 +5349,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "mkdirp": {
@@ -5380,9 +5416,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ=="
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
     },
     "once": {
       "version": "1.4.0",
@@ -5483,9 +5519,9 @@
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
     "postcss": {
-      "version": "8.4.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
       "dev": true,
       "requires": {
         "nanoid": "^3.3.4",
@@ -5500,9 +5536,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
-      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true
     },
     "prettier-plugin-svelte": {
@@ -5519,15 +5555,15 @@
       "dev": true
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true
     },
     "qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+      "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
       "requires": {
         "side-channel": "^1.0.4"
       }
@@ -5598,9 +5634,9 @@
       }
     },
     "rollup": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.7.4.tgz",
-      "integrity": "sha512-jN9rx3k5pfg9H9al0r0y1EYKSeiRANZRYX32SuNXAnKzh6cVyf4LZVto1KAuDnbHT03E1CpsgqDKaqQ8FZtgxw==",
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.19.1.tgz",
+      "integrity": "sha512-lAbrdN7neYCg/8WaoWn/ckzCtz+jr70GFfYdlf50OF7387HTg+wiuiqJRFYawwSPpqfqDNYqK7smY/ks2iAudg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -5645,6 +5681,17 @@
             "glob": "^7.1.3"
           }
         }
+      }
+    },
+    "sass": {
+      "version": "1.59.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.59.2.tgz",
+      "integrity": "sha512-jJyO6SmbzkJexF8MUorHx5tAilcgabioYxT/BHbY4+OvoqmbHxsYlrjZ8Adhqcgl6Zqwie0TgMXLCAmPFxXOuw==",
+      "dev": true,
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
       }
     },
     "semver": {
@@ -5716,15 +5763,15 @@
       }
     },
     "sorcery": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
-      "integrity": "sha512-R5ocFmKZQFfSTstfOtHjJuAwbpGyf9qjQa1egyhvXSbM7emjrtLXtGdZsDJDABC85YBfVvrOiGWKSYXPKdvP1g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.11.0.tgz",
+      "integrity": "sha512-J69LQ22xrQB1cIFJhPfgtLuI6BpWRiWu1Y3vSsIwK/eAScqJxd/+CJlUuHQRdX2C9NGFamq+KqNywGgaThwfHw==",
       "dev": true,
       "requires": {
+        "@jridgewell/sourcemap-codec": "^1.4.14",
         "buffer-crc32": "^0.2.5",
         "minimist": "^1.2.0",
-        "sander": "^0.5.0",
-        "sourcemap-codec": "^1.3.0"
+        "sander": "^0.5.0"
       }
     },
     "source-map": {
@@ -5748,12 +5795,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -5818,10 +5859,9 @@
       "dev": true
     },
     "svelte": {
-      "version": "3.55.0",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.55.0.tgz",
-      "integrity": "sha512-uGu2FVMlOuey4JoKHKrpZFkoYyj0VLjJdz47zX5+gVK5odxHM40RVhar9/iK2YFRVxvfg9FkhfVlR0sjeIrOiA==",
-      "dev": true
+      "version": "3.56.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.56.0.tgz",
+      "integrity": "sha512-LvXiJbjdvJKwB/0CQyYpDX0q+hFqCyWmybzC2G6eK1tJJA/RSRCytTfNmjHv+RHlLuA70vWG7nXp6gbeErYvRA=="
     },
     "svelte-animated-details": {
       "version": "1.0.1",
@@ -5829,9 +5869,9 @@
       "integrity": "sha512-solG1K+4gVwPQuHLxQvxr9JSZnLWD4ANcTuH3vGe2ors+mZQRW+doKGhLvI8twlel/5zkVW1CqqMCeF25+NKNg=="
     },
     "svelte-check": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.1.2.tgz",
-      "integrity": "sha512-8nIPXPe8TiUiWPCAoegU+l1NaL5DKLnN6+H1dJqbjkD6IkhpDTMj2q8Z88lhCOsq1F3E7st5/Vn7eGeGkSo/aA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.1.4.tgz",
+      "integrity": "sha512-25Lb46ZS4IK/XpBMe4IBMrtYf23V8alqBX+szXoccb7uM0D2Wqq5rMRzYBONZnFVuU1bQG3R50lyIT5eRewv2g==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.17",
@@ -5852,17 +5892,28 @@
       "requires": {}
     },
     "svelte-preprocess": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.0.tgz",
-      "integrity": "sha512-q7lpa7i2FBu8Pa+G0MmuQQWETBwCKgsGmuq1Sf6n8q4uaG9ZLcLP0Y+etC6bF4sE6EbLxfiI38zV6RfPe3RSfg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/svelte-preprocess/-/svelte-preprocess-5.0.1.tgz",
+      "integrity": "sha512-0HXyhCoc9rsW4zGOgtInylC6qj259E1hpFnJMJWTf+aIfeqh4O/QHT31KT2hvPEqQfdjmqBR/kO2JDkkciBLrQ==",
       "dev": true,
       "requires": {
         "@types/pug": "^2.0.6",
         "@types/sass": "^1.43.1",
         "detect-indent": "^6.1.0",
         "magic-string": "^0.27.0",
-        "sorcery": "^0.10.0",
+        "sorcery": "^0.11.0",
         "strip-indent": "^3.0.0"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+          "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
       }
     },
     "table": {
@@ -5879,9 +5930,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-          "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -5899,9 +5950,9 @@
       }
     },
     "terser": {
-      "version": "5.16.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-      "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+      "version": "5.16.6",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.6.tgz",
+      "integrity": "sha512-IBZ+ZQIA9sMaXmRZCUMDjNH0D5AQQfdn4WUjHL0+1lF4TP1IHRJbrhb6fNaXWikrYQTSkb7SLxkeXAiy1p7mbg==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
@@ -5911,9 +5962,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.8.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+          "version": "8.8.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+          "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
           "dev": true
         },
         "commander": {
@@ -5956,9 +6007,9 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
       "dev": true
     },
     "tsutils": {
@@ -5994,9 +6045,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "undici": {
@@ -6024,16 +6075,16 @@
       "dev": true
     },
     "vite": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.1.tgz",
-      "integrity": "sha512-kZQPzbDau35iWOhy3CpkrRC7It+HIHtulAzBhMqzGHKRf/4+vmh8rPDDdv98SWQrFWo6//3ozwsRmwQIPZsK9g==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.1.4.tgz",
+      "integrity": "sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==",
       "dev": true,
       "requires": {
-        "esbuild": "^0.16.3",
+        "esbuild": "^0.16.14",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.20",
+        "postcss": "^8.4.21",
         "resolve": "^1.22.1",
-        "rollup": "^3.7.0"
+        "rollup": "^3.10.0"
       }
     },
     "vitefu": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "hack4impact-uiuc",
       "version": "0.0.1",
       "dependencies": {
-        "@iconify/svelte": "^3.1.0",
         "ackee-tracker": "^5.1.0",
         "contentful": "^9.1.5",
         "svelte-animated-details": "^1.0.1"
@@ -16,6 +15,9 @@
       "devDependencies": {
         "@contentful/rich-text-html-renderer": "^15.0.0",
         "@contentful/rich-text-types": "^15.0.0",
+        "@iconify-icons/bx": "^1.2.6",
+        "@iconify-icons/bxs": "^1.2.6",
+        "@iconify/svelte": "^3.1.0",
         "@sveltejs/adapter-netlify": "^2.0.6",
         "@sveltejs/kit": "^1.11.0",
         "@types/ackee-tracker": "^5.0.1",
@@ -591,10 +593,29 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "dev": true
     },
+    "node_modules/@iconify-icons/bx": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@iconify-icons/bx/-/bx-1.2.6.tgz",
+      "integrity": "sha512-D8Ns/AqQoJzTxfrlpRWfh53m/0Uh2bMjgvGlVrmBw+1HrNyCJgqEa6mo2KAtZ4xjvzHn0cjTOnu+R0KYq+RmSg==",
+      "dev": true,
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify-icons/bxs": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@iconify-icons/bxs/-/bxs-1.2.6.tgz",
+      "integrity": "sha512-pDJZgTigltdvlExgRaY8V5fH4C7aJKB1xm42auO6oRwLXw7vFLrBtfz42MWmtczGE3LRzoTORU8OcLMyjVTQtg==",
+      "dev": true,
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
     "node_modules/@iconify/svelte": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@iconify/svelte/-/svelte-3.1.0.tgz",
       "integrity": "sha512-G1w1dcO7eiD+JmQJNwNW4qnAn86oQxKLe1P/iAPjJ0qYYuF7Pb60TPrlcj4+2gu4SXe3a0Jrv++8YmceG+gX/g==",
+      "dev": true,
       "dependencies": {
         "@iconify/types": "^2.0.0"
       },
@@ -608,7 +629,8 @@
     "node_modules/@iconify/types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -3216,6 +3238,7 @@
       "version": "3.56.0",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.56.0.tgz",
       "integrity": "sha512-LvXiJbjdvJKwB/0CQyYpDX0q+hFqCyWmybzC2G6eK1tJJA/RSRCytTfNmjHv+RHlLuA70vWG7nXp6gbeErYvRA==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -3954,10 +3977,29 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
       "dev": true
     },
+    "@iconify-icons/bx": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@iconify-icons/bx/-/bx-1.2.6.tgz",
+      "integrity": "sha512-D8Ns/AqQoJzTxfrlpRWfh53m/0Uh2bMjgvGlVrmBw+1HrNyCJgqEa6mo2KAtZ4xjvzHn0cjTOnu+R0KYq+RmSg==",
+      "dev": true,
+      "requires": {
+        "@iconify/types": "*"
+      }
+    },
+    "@iconify-icons/bxs": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@iconify-icons/bxs/-/bxs-1.2.6.tgz",
+      "integrity": "sha512-pDJZgTigltdvlExgRaY8V5fH4C7aJKB1xm42auO6oRwLXw7vFLrBtfz42MWmtczGE3LRzoTORU8OcLMyjVTQtg==",
+      "dev": true,
+      "requires": {
+        "@iconify/types": "*"
+      }
+    },
     "@iconify/svelte": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@iconify/svelte/-/svelte-3.1.0.tgz",
       "integrity": "sha512-G1w1dcO7eiD+JmQJNwNW4qnAn86oQxKLe1P/iAPjJ0qYYuF7Pb60TPrlcj4+2gu4SXe3a0Jrv++8YmceG+gX/g==",
+      "dev": true,
       "requires": {
         "@iconify/types": "^2.0.0"
       }
@@ -3965,7 +4007,8 @@
     "@iconify/types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true
     },
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -5861,7 +5904,8 @@
     "svelte": {
       "version": "3.56.0",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.56.0.tgz",
-      "integrity": "sha512-LvXiJbjdvJKwB/0CQyYpDX0q+hFqCyWmybzC2G6eK1tJJA/RSRCytTfNmjHv+RHlLuA70vWG7nXp6gbeErYvRA=="
+      "integrity": "sha512-LvXiJbjdvJKwB/0CQyYpDX0q+hFqCyWmybzC2G6eK1tJJA/RSRCytTfNmjHv+RHlLuA70vWG7nXp6gbeErYvRA==",
+      "dev": true
     },
     "svelte-animated-details": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
       "devDependencies": {
         "@contentful/rich-text-html-renderer": "^15.0.0",
         "@contentful/rich-text-types": "^15.0.0",
-        "@sveltejs/adapter-netlify": "^1.0.0",
-        "@sveltejs/kit": "^1.0.0",
+        "@sveltejs/adapter-netlify": "^2.0.6",
+        "@sveltejs/kit": "^1.11.0",
         "@types/ackee-tracker": "^5.0.1",
         "@types/html-minifier-terser": "^6.1.0",
         "@typescript-eslint/eslint-plugin": "^5.30.6",
@@ -30,7 +30,7 @@
         "prettier": "^2.8.3",
         "prettier-plugin-svelte": "^2.2.0",
         "svelte": "^3.55.0",
-        "svelte-check": "^3.0.1",
+        "svelte-check": "^3.1.2",
         "tslib": "^2.0.0",
         "typescript": "^4.9.0",
         "vite": "^4.0.1"
@@ -668,9 +668,9 @@
       "dev": true
     },
     "node_modules/@sveltejs/adapter-netlify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-1.0.0.tgz",
-      "integrity": "sha512-D4tsvLSuJHeqbPatMcpVzUYd2CeIkTQH/L0RHTvl0cyZOJsnkwfWysv7BZmc9OVAbp5XzHggFTwSTH+M9cYLww==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-2.0.6.tgz",
+      "integrity": "sha512-9guxI9jG/v/JTr/I1E1YGKppKWRyvs60VuhPJcGBrj2MfoBxR40vhxkrWPFcNJoAdyQUSjqxbg7sZLA4WbNfgA==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "^2.2.5",
@@ -678,53 +678,65 @@
         "set-cookie-parser": "^2.5.1"
       },
       "peerDependencies": {
-        "@sveltejs/kit": "^1.0.0"
+        "@sveltejs/kit": "^1.5.0"
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0.tgz",
-      "integrity": "sha512-6VgD5C3i2XOT7GRBi5LaPPLiFAmpiDkhKJNVt8fLg1RmaL6f7rT4Kiwi2XGpYRj3V1F4t1QRdsfmAkkDUKY3OA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.11.0.tgz",
+      "integrity": "sha512-PwViZcMoLgEU/jhLoSyjf5hSrHS67wvSm0ifBo4prP9irpGa5HuPOZeVDTL5tPDSBoKxtdYi1zlGdoiJfO86jA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@types/cookie": "^0.5.1",
         "cookie": "^0.5.0",
-        "devalue": "^4.2.0",
+        "devalue": "^4.3.0",
         "esm-env": "^1.0.0",
         "kleur": "^4.1.5",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.30.0",
         "mime": "^3.0.0",
         "sade": "^1.8.1",
         "set-cookie-parser": "^2.5.1",
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
-        "undici": "5.14.0"
+        "undici": "5.20.0"
       },
       "bin": {
         "svelte-kit": "svelte-kit.js"
       },
       "engines": {
-        "node": ">=16.14"
+        "node": "^16.14 || >=18"
       },
       "peerDependencies": {
         "svelte": "^3.54.0",
         "vite": "^4.0.0"
       }
     },
+    "node_modules/@sveltejs/kit/node_modules/magic-string": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.2.tgz",
-      "integrity": "sha512-xCEan0/NNpQuL0l5aS42FjwQ6wwskdxC3pW1OeFtEKNZwRg7Evro9lac9HesGP6TdFsTv2xMes5ASQVKbCacxg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.3.tgz",
+      "integrity": "sha512-o+cguBFdwIGtRbNkYOyqTM7KvRUffxh5bfK4oJsWKG2obu+v/cbpT03tJrGl58C7tRXo/aEC0/axN5FVHBj0nA==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
-        "deepmerge": "^4.2.2",
+        "deepmerge": "^4.3.0",
         "kleur": "^4.1.5",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.29.0",
         "svelte-hmr": "^0.15.1",
-        "vitefu": "^0.2.3"
+        "vitefu": "^0.2.4"
       },
       "engines": {
         "node": "^14.18.0 || >= 16"
@@ -732,6 +744,18 @@
       "peerDependencies": {
         "svelte": "^3.54.0",
         "vite": "^4.0.0"
+      }
+    },
+    "node_modules/@sveltejs/vite-plugin-svelte/node_modules/magic-string": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
+      "integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@svicons/boxicons-regular": {
@@ -1397,9 +1421,9 @@
       "dev": true
     },
     "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -1423,9 +1447,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.2.0.tgz",
-      "integrity": "sha512-mbjoAaCL2qogBKgeFxFPOXAUsZchircF+B/79LD4sHH0+NHfYm8gZpQrskKDn5gENGt35+5OI1GUF7hLVnkPDw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.0.tgz",
+      "integrity": "sha512-n94yQo4LI3w7erwf84mhRUkUJfhLoCZiLyoOZ/QFsDbcWNZePrLwbQpvZBUG2TNxwV3VjCKPxkiiQA6pe3TrTA==",
       "dev": true
     },
     "node_modules/dir-glob": {
@@ -3183,9 +3207,9 @@
       "integrity": "sha512-solG1K+4gVwPQuHLxQvxr9JSZnLWD4ANcTuH3vGe2ors+mZQRW+doKGhLvI8twlel/5zkVW1CqqMCeF25+NKNg=="
     },
     "node_modules/svelte-check": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.0.1.tgz",
-      "integrity": "sha512-7YpHYWv6V2qhcvVeAlXixUPAlpLCXB1nZEQK0EItB3PtuYmENhKclbc5uKSJTodTwWR1y+4stKGcbH30k6A3Yw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.1.2.tgz",
+      "integrity": "sha512-8nIPXPe8TiUiWPCAoegU+l1NaL5DKLnN6+H1dJqbjkD6IkhpDTMj2q8Z88lhCOsq1F3E7st5/Vn7eGeGkSo/aA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.17",
@@ -3455,9 +3479,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dev": true,
       "dependencies": {
         "busboy": "^1.6.0"
@@ -3966,9 +3990,9 @@
       "dev": true
     },
     "@sveltejs/adapter-netlify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-1.0.0.tgz",
-      "integrity": "sha512-D4tsvLSuJHeqbPatMcpVzUYd2CeIkTQH/L0RHTvl0cyZOJsnkwfWysv7BZmc9OVAbp5XzHggFTwSTH+M9cYLww==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@sveltejs/adapter-netlify/-/adapter-netlify-2.0.6.tgz",
+      "integrity": "sha512-9guxI9jG/v/JTr/I1E1YGKppKWRyvs60VuhPJcGBrj2MfoBxR40vhxkrWPFcNJoAdyQUSjqxbg7sZLA4WbNfgA==",
       "dev": true,
       "requires": {
         "@iarna/toml": "^2.2.5",
@@ -3977,38 +4001,60 @@
       }
     },
     "@sveltejs/kit": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0.tgz",
-      "integrity": "sha512-6VgD5C3i2XOT7GRBi5LaPPLiFAmpiDkhKJNVt8fLg1RmaL6f7rT4Kiwi2XGpYRj3V1F4t1QRdsfmAkkDUKY3OA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.11.0.tgz",
+      "integrity": "sha512-PwViZcMoLgEU/jhLoSyjf5hSrHS67wvSm0ifBo4prP9irpGa5HuPOZeVDTL5tPDSBoKxtdYi1zlGdoiJfO86jA==",
       "dev": true,
       "requires": {
         "@sveltejs/vite-plugin-svelte": "^2.0.0",
         "@types/cookie": "^0.5.1",
         "cookie": "^0.5.0",
-        "devalue": "^4.2.0",
+        "devalue": "^4.3.0",
         "esm-env": "^1.0.0",
         "kleur": "^4.1.5",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.30.0",
         "mime": "^3.0.0",
         "sade": "^1.8.1",
         "set-cookie-parser": "^2.5.1",
         "sirv": "^2.0.2",
         "tiny-glob": "^0.2.9",
-        "undici": "5.14.0"
+        "undici": "5.20.0"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.30.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+          "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
       }
     },
     "@sveltejs/vite-plugin-svelte": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.2.tgz",
-      "integrity": "sha512-xCEan0/NNpQuL0l5aS42FjwQ6wwskdxC3pW1OeFtEKNZwRg7Evro9lac9HesGP6TdFsTv2xMes5ASQVKbCacxg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-2.0.3.tgz",
+      "integrity": "sha512-o+cguBFdwIGtRbNkYOyqTM7KvRUffxh5bfK4oJsWKG2obu+v/cbpT03tJrGl58C7tRXo/aEC0/axN5FVHBj0nA==",
       "dev": true,
       "requires": {
         "debug": "^4.3.4",
-        "deepmerge": "^4.2.2",
+        "deepmerge": "^4.3.0",
         "kleur": "^4.1.5",
-        "magic-string": "^0.27.0",
+        "magic-string": "^0.29.0",
         "svelte-hmr": "^0.15.1",
-        "vitefu": "^0.2.3"
+        "vitefu": "^0.2.4"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.29.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
+          "integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
       }
     },
     "@svicons/boxicons-regular": {
@@ -4481,9 +4527,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.0.tgz",
+      "integrity": "sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==",
       "dev": true
     },
     "delayed-stream": {
@@ -4498,9 +4544,9 @@
       "dev": true
     },
     "devalue": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.2.0.tgz",
-      "integrity": "sha512-mbjoAaCL2qogBKgeFxFPOXAUsZchircF+B/79LD4sHH0+NHfYm8gZpQrskKDn5gENGt35+5OI1GUF7hLVnkPDw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.0.tgz",
+      "integrity": "sha512-n94yQo4LI3w7erwf84mhRUkUJfhLoCZiLyoOZ/QFsDbcWNZePrLwbQpvZBUG2TNxwV3VjCKPxkiiQA6pe3TrTA==",
       "dev": true
     },
     "dir-glob": {
@@ -5783,9 +5829,9 @@
       "integrity": "sha512-solG1K+4gVwPQuHLxQvxr9JSZnLWD4ANcTuH3vGe2ors+mZQRW+doKGhLvI8twlel/5zkVW1CqqMCeF25+NKNg=="
     },
     "svelte-check": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.0.1.tgz",
-      "integrity": "sha512-7YpHYWv6V2qhcvVeAlXixUPAlpLCXB1nZEQK0EItB3PtuYmENhKclbc5uKSJTodTwWR1y+4stKGcbH30k6A3Yw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.1.2.tgz",
+      "integrity": "sha512-8nIPXPe8TiUiWPCAoegU+l1NaL5DKLnN6+H1dJqbjkD6IkhpDTMj2q8Z88lhCOsq1F3E7st5/Vn7eGeGkSo/aA==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.17",
@@ -5954,9 +6000,9 @@
       "dev": true
     },
     "undici": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.14.0.tgz",
-      "integrity": "sha512-yJlHYw6yXPPsuOH0x2Ib1Km61vu4hLiRRQoafs+WUgX1vO64vgnxiCEN9dpIrhZyHFsai3F0AEj4P9zy19enEQ==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dev": true,
       "requires": {
         "busboy": "^1.6.0"

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "vite": "^4.0.1"
   },
   "dependencies": {
-    "@svicons/boxicons-regular": "^0.1.3",
-    "@svicons/boxicons-solid": "^0.1.3",
+    "@iconify/svelte": "^3.1.0",
     "ackee-tracker": "^5.1.0",
     "contentful": "^9.1.5",
     "svelte-animated-details": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "devDependencies": {
     "@contentful/rich-text-html-renderer": "^15.0.0",
     "@contentful/rich-text-types": "^15.0.0",
-    "@sveltejs/adapter-netlify": "^1.0.0",
-    "@sveltejs/kit": "^1.0.0",
+    "@sveltejs/adapter-netlify": "^2.0.6",
+    "@sveltejs/kit": "^1.11.0",
     "@types/ackee-tracker": "^5.0.1",
     "@types/html-minifier-terser": "^6.1.0",
     "@typescript-eslint/eslint-plugin": "^5.30.6",
@@ -29,7 +29,7 @@
     "prettier": "^2.8.3",
     "prettier-plugin-svelte": "^2.2.0",
     "svelte": "^3.55.0",
-    "svelte-check": "^3.0.1",
+    "svelte-check": "^3.1.2",
     "tslib": "^2.0.0",
     "typescript": "^4.9.0",
     "vite": "^4.0.1"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "devDependencies": {
     "@contentful/rich-text-html-renderer": "^15.0.0",
     "@contentful/rich-text-types": "^15.0.0",
+    "@iconify-icons/bx": "^1.2.6",
+    "@iconify-icons/bxs": "^1.2.6",
+    "@iconify/svelte": "^3.1.0",
     "@sveltejs/adapter-netlify": "^2.0.6",
     "@sveltejs/kit": "^1.11.0",
     "@types/ackee-tracker": "^5.0.1",
@@ -35,7 +38,6 @@
     "vite": "^4.0.1"
   },
   "dependencies": {
-    "@iconify/svelte": "^3.1.0",
     "ackee-tracker": "^5.1.0",
     "contentful": "^9.1.5",
     "svelte-animated-details": "^1.0.1"

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -1,47 +1,81 @@
 <script context="module" lang="ts">
+  import brainFill from "@iconify-icons/bx/brain";
+  import code_altFill from "@iconify-icons/bx/code-alt";
+  import editFill from "@iconify-icons/bx/edit";
+  import healthFill from "@iconify-icons/bx/health";
+  import question_markFill from "@iconify-icons/bx/question-mark";
+  import searchFill from "@iconify-icons/bx/search";
+  import transfer_altFill from "@iconify-icons/bx/transfer-alt";
+  import unlinkFill from "@iconify-icons/bx/unlink";
+  import badge_dollarFill from "@iconify-icons/bxs/badge-dollar";
+  import bookFill from "@iconify-icons/bxs/book";
+  import bulbFill from "@iconify-icons/bxs/bulb";
+  import calendarFill from "@iconify-icons/bxs/calendar";
+  import chalkboardFill from "@iconify-icons/bxs/chalkboard";
+  import chevron_rightFill from "@iconify-icons/bxs/chevron-right";
+  import coffeeFill from "@iconify-icons/bxs/coffee";
+  import conversationFill from "@iconify-icons/bxs/conversation";
+  import devicesFill from "@iconify-icons/bxs/devices";
+  import donate_heartFill from "@iconify-icons/bxs/donate-heart";
+  import graduationFill from "@iconify-icons/bxs/graduation";
+  import groupFill from "@iconify-icons/bxs/group";
+  import heartFill from "@iconify-icons/bxs/heart";
+  import home_heartFill from "@iconify-icons/bxs/home-heart";
+  import message_xFill from "@iconify-icons/bxs/message-x";
+  import newsFill from "@iconify-icons/bxs/news";
+  import plane_altFill from "@iconify-icons/bxs/plane-alt";
+  import shieldFill from "@iconify-icons/bxs/shield";
+  import slideshowFill from "@iconify-icons/bxs/slideshow";
+  import tagFill from "@iconify-icons/bxs/tag";
+  import treeFill from "@iconify-icons/bxs/tree";
+  import vectorFill from "@iconify-icons/bxs/vector";
+  import Icon, { addIcon } from "@iconify/svelte/dist/OfflineIcon.svelte";
+
   const iconMap = {
-    brain: "bx:brain",
-    code: "bx:code-alt",
-    edit: "bx:edit",
-    health: "bx:health",
-    question: "bx:question-mark",
-    search: "bx:search",
-    transfer: "bx:transfer-alt",
-    unlink: "bx:unlink",
-    dollar: "bxs:badge-dollar",
-    book: "bxs:book",
-    bulb: "bxs:bulb",
-    calendar: "bxs:calendar",
-    chalkboard: "bxs:chalkboard",
-    "chevron-right": "bxs:chevron-right",
-    coffee: "bxs:coffee",
-    conversation: "bxs:conversation",
-    devices: "bxs:devices",
-    donate: "bxs:donate-heart",
-    education: "bxs:graduation",
-    group: "bxs:group",
-    heart: "bxs:heart",
-    hate: "bxs:message-x",
-    news: "bxs:news",
-    plane: "bxs:plane-alt",
-    shield: "bxs:shield",
-    slideshow: "bxs:slideshow",
-    tag: "bxs:tag",
-    tree: "bxs:tree",
-    vector: "bxs:vector",
-    volunteering: "bxs:home-heart",
-  };
+    brain: { name: "brain", fill: brainFill },
+    code: { name: "code-alt", fill: code_altFill },
+    edit: { name: "edit", fill: editFill },
+    health: { name: "health", fill: healthFill },
+    question: { name: "question-mark", fill: question_markFill },
+    search: { name: "search", fill: searchFill },
+    transfer: { name: "transfer-alt", fill: transfer_altFill },
+    unlink: { name: "unlink", fill: unlinkFill },
+    dollar: { name: "badge-dollar", fill: badge_dollarFill },
+    book: { name: "book", fill: bookFill },
+    bulb: { name: "bulb", fill: bulbFill },
+    calendar: { name: "calendar", fill: calendarFill },
+    chalkboard: { name: "chalkboard", fill: chalkboardFill },
+    "chevron-right": { name: "chevron-right", fill: chevron_rightFill },
+    coffee: { name: "coffee", fill: coffeeFill },
+    conversation: { name: "conversation", fill: conversationFill },
+    devices: { name: "devices", fill: devicesFill },
+    donate: { name: "donate-heart", fill: donate_heartFill },
+    education: { name: "graduation", fill: graduationFill },
+    group: { name: "group", fill: groupFill },
+    heart: { name: "heart", fill: heartFill },
+    hate: { name: "message-x", fill: message_xFill },
+    news: { name: "news", fill: newsFill },
+    plane: { name: "plane-alt", fill: plane_altFill },
+    shield: { name: "shield", fill: shieldFill },
+    slideshow: { name: "slideshow", fill: slideshowFill },
+    tag: { name: "tag", fill: tagFill },
+    tree: { name: "tree", fill: treeFill },
+    vector: { name: "vector", fill: vectorFill },
+    volunteering: { name: "home-heart", fill: home_heartFill },
+  } as const;
+
+  for (const { name, fill } of Object.values(iconMap)) {
+    addIcon(name, fill);
+  }
 
   export type IconType = keyof typeof iconMap;
 </script>
 
 <script lang="ts">
-  import Icon from "@iconify/svelte";
-
   export let icon: IconType;
   export let width: string | number = "100%";
   export let height: string | number = "100%";
   export let color = "currentColor";
 </script>
 
-<Icon icon={iconMap[icon]} {width} {height} {color} />
+<Icon icon={iconMap[icon].name} {width} {height} {color} />

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -1,113 +1,47 @@
 <script context="module" lang="ts">
-  import Brain from "@svicons/boxicons-regular/brain.svelte";
-  import Code from "@svicons/boxicons-regular/code-alt.svelte";
-  import Edit from "@svicons/boxicons-regular/edit.svelte";
-  import Health from "@svicons/boxicons-regular/health.svelte";
-  import Question from "@svicons/boxicons-regular/question-mark.svelte";
-  import Search from "@svicons/boxicons-regular/search.svelte";
-  import Transfer from "@svicons/boxicons-regular/transfer-alt.svelte";
-  import Unlink from "@svicons/boxicons-regular/unlink.svelte";
-  import Dollar from "@svicons/boxicons-solid/badge-dollar.svelte";
-  import Book from "@svicons/boxicons-solid/book.svelte";
-  import Bulb from "@svicons/boxicons-solid/bulb.svelte";
-  import Calendar from "@svicons/boxicons-solid/calendar.svelte";
-  import Chalkboard from "@svicons/boxicons-solid/chalkboard.svelte";
-  import ChevronCompactRight from "@svicons/boxicons-solid/chevron-right.svelte";
-  import Coffee from "@svicons/boxicons-solid/coffee.svelte";
-  import Conversation from "@svicons/boxicons-solid/conversation.svelte";
-  import Devices from "@svicons/boxicons-solid/devices.svelte";
-  import DonateHeart from "@svicons/boxicons-solid/donate-heart.svelte";
-  import Graduation from "@svicons/boxicons-solid/graduation.svelte";
-  import Group from "@svicons/boxicons-solid/group.svelte";
-  import Heart from "@svicons/boxicons-solid/heart.svelte";
-  import MessageX from "@svicons/boxicons-solid/message-x.svelte";
-  import News from "@svicons/boxicons-solid/news.svelte";
-  import Plane from "@svicons/boxicons-solid/plane-alt.svelte";
-  import Shield from "@svicons/boxicons-solid/shield.svelte";
-  import Slideshow from "@svicons/boxicons-solid/slideshow.svelte";
-  import Tag from "@svicons/boxicons-solid/tag.svelte";
-  import Tree from "@svicons/boxicons-solid/tree.svelte";
-  import Vector from "@svicons/boxicons-solid/vector.svelte";
-  import HomeHeart from "@svicons/boxicons-solid/home-heart.svelte";
-  import type { SVGAttributes } from "svelte/elements";
-
-  import type { ComponentType, SvelteComponentTyped } from "svelte";
-
-  export type IconType =
-    | "brain"
-    | "bulb"
-    | "book"
-    | "calendar"
-    | "code"
-    | "coffee"
-    | "chalkboard"
-    | "conversation"
-    | "devices"
-    | "edit"
-    | "heart"
-    | "question"
-    | "group"
-    | "search"
-    | "slideshow"
-    | "transfer"
-    | "vector"
-    | "health"
-    | "education"
-    | "tag"
-    | "tree"
-    | "donate"
-    | "shield"
-    | "hate"
-    | "news"
-    | "dollar"
-    | "plane"
-    | "unlink"
-    | "chevron-right"
-    | "volunteering";
-
-  const iconMap: Record<
-    IconType,
-    ComponentType<SvelteComponentTyped<SVGAttributes<SVGSVGElement>>>
-  > = {
-    brain: Brain,
-    bulb: Bulb,
-    book: Book,
-    calendar: Calendar,
-    code: Code,
-    coffee: Coffee,
-    chalkboard: Chalkboard,
-    conversation: Conversation,
-    devices: Devices,
-    edit: Edit,
-    heart: Heart,
-    question: Question,
-    group: Group,
-    search: Search,
-    slideshow: Slideshow,
-    tag: Tag,
-    transfer: Transfer,
-    vector: Vector,
-    health: Health,
-    education: Graduation,
-    tree: Tree,
-    donate: DonateHeart,
-    shield: Shield,
-    hate: MessageX,
-    news: News,
-    dollar: Dollar,
-    plane: Plane,
-    unlink: Unlink,
-    "chevron-right": ChevronCompactRight,
-    volunteering: HomeHeart,
+  const iconMap = {
+    brain: "bx:brain",
+    code: "bx:code-alt",
+    edit: "bx:edit",
+    health: "bx:health",
+    question: "bx:question-mark",
+    search: "bx:search",
+    transfer: "bx:transfer-alt",
+    unlink: "bx:unlink",
+    dollar: "bxs:badge-dollar",
+    book: "bxs:book",
+    bulb: "bxs:bulb",
+    calendar: "bxs:calendar",
+    chalkboard: "bxs:chalkboard",
+    "chevron-right": "bxs:chevron-right",
+    coffee: "bxs:coffee",
+    conversation: "bxs:conversation",
+    devices: "bxs:devices",
+    donate: "bxs:donate-heart",
+    education: "bxs:graduation",
+    group: "bxs:group",
+    heart: "bxs:heart",
+    hate: "bxs:message-x",
+    news: "bxs:news",
+    plane: "bxs:plane-alt",
+    shield: "bxs:shield",
+    slideshow: "bxs:slideshow",
+    tag: "bxs:tag",
+    tree: "bxs:tree",
+    vector: "bxs:vector",
+    volunteering: "bxs:home-heart",
   };
+
+  export type IconType = keyof typeof iconMap;
 </script>
 
 <script lang="ts">
-  export let icon: IconType;
+  import Icon from "@iconify/svelte";
 
-  interface $$Props extends SVGAttributes<SVGSVGElement> {
-    icon: IconType;
-  }
+  export let icon: IconType;
+  export let width: string | number = "100%";
+  export let height: string | number = "100%";
+  export let color: string = "currentColor";
 </script>
 
-<svelte:component this={iconMap[icon]} {...$$restProps} />
+<Icon icon={iconMap[icon]} {width} {height} {color} />

--- a/src/lib/components/Icon.svelte
+++ b/src/lib/components/Icon.svelte
@@ -41,7 +41,7 @@
   export let icon: IconType;
   export let width: string | number = "100%";
   export let height: string | number = "100%";
-  export let color: string = "currentColor";
+  export let color = "currentColor";
 </script>
 
 <Icon icon={iconMap[icon]} {width} {height} {color} />

--- a/src/lib/components/Step.svelte
+++ b/src/lib/components/Step.svelte
@@ -8,9 +8,9 @@
 
 <div class="step row-center">
   <span
-    ><div id="icon-container">
+    ><div class="icon-container">
       {#if icon !== undefined}
-        <Icon {icon} />
+        <Icon {icon} color="var(--blue-lighter)" height="50px" />
       {:else if index !== undefined}
         <span class="step-index">{index}</span>
       {/if}
@@ -33,7 +33,7 @@
     opacity: 80%;
   }
 
-  #icon-container {
+  .icon-container {
     width: 100px;
     height: 100px;
     border-radius: 100%;
@@ -42,11 +42,6 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-  }
-
-  :global(.step #icon-container svg) {
-    height: 50px;
-    color: var(--blue-lighter);
   }
 
   .step {

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,18 +1,17 @@
 import type { ContentWrapper } from "$lib/utils/api";
 import { generateProjectsInfo } from "$lib/utils/projects";
 import type { Info, Project } from "$lib/utils/schema";
-import type { LayoutServerLoad } from "./$types";
 
 export const prerender = true;
 
-export const load: LayoutServerLoad = ({ locals }) => {
+export function load({ locals }) {
   return {
     semesters: getSemesters(locals.contentWrapper),
     info: locals.contentWrapper
       .get("info")
       .then((infoList) => infoList[0]) as Promise<Info>,
   };
-};
+}
 
 async function getSemesters(contentWrapper: ContentWrapper) {
   const projects: Project[] = await contentWrapper.get("project");

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,12 +4,12 @@
   import { env } from "$env/dynamic/public";
   import Nav from "$lib/components/Nav.svelte";
   import Footer from "$lib/components/Footer.svelte";
-  import type { PageData } from "./$types";
+
   import Head from "$lib/components/Head.svelte";
   import { page } from "$app/stores";
   import SkipLink from "$lib/components/SkipLink.svelte";
 
-  export let data: PageData;
+  export let data;
 
   const baseTitle = "Hack4Impact UIUC";
   $: title = $page.data.title

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,7 +4,6 @@
   import { env } from "$env/dynamic/public";
   import Nav from "$lib/components/Nav.svelte";
   import Footer from "$lib/components/Footer.svelte";
-
   import Head from "$lib/components/Head.svelte";
   import { page } from "$app/stores";
   import SkipLink from "$lib/components/SkipLink.svelte";

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,13 +1,12 @@
 import type { ContentWrapper } from "$lib/utils/api";
 import { shuffleArray } from "$lib/utils/projects";
 import type { Project } from "$lib/utils/schema";
-import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = ({ locals }) => {
+export function load({ locals }) {
   return {
     projects: getFeaturedProjects(locals.contentWrapper),
   };
-};
+}
 
 async function getFeaturedProjects(contentWrapper: ContentWrapper) {
   const projects: Project[] = await contentWrapper.get("project", {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,9 +7,8 @@
   import Row from "$lib/components/Row.svelte";
   import Section from "$lib/components/Section.svelte";
   import { setImageHeight } from "$lib/utils/schema";
-  import type { PageData } from "./$types";
 
-  export let data: PageData;
+  export let data;
 </script>
 
 <DoubleBanner

--- a/src/routes/about/+page.server.ts
+++ b/src/routes/about/+page.server.ts
@@ -1,13 +1,12 @@
 import type { ContentWrapper } from "$lib/utils/api";
 import type { Member, TestimonialMember } from "$lib/utils/schema";
-import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = ({ locals }) => {
+export function load({ locals }) {
   return {
     title: "About Us",
     testimonialMember: getTestimonialMember(locals.contentWrapper),
   };
-};
+}
 
 async function getTestimonialMember(contentWrapper: ContentWrapper) {
   const members: Member[] = await contentWrapper.get("member");

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -5,9 +5,8 @@
   import Step from "$lib/components/Step.svelte";
   import Testimonial from "$lib/components/Testimonial.svelte";
   import { setImageHeight } from "$lib/utils/schema";
-  import type { PageData } from "./$types";
 
-  export let data: PageData;
+  export let data;
 </script>
 
 <Section id="intro" padding="60px">

--- a/src/routes/about/team/+page.server.ts
+++ b/src/routes/about/team/+page.server.ts
@@ -1,5 +1,5 @@
 import type { ContentWrapper } from "$lib/utils/api";
-import type { Member } from "src/lib/utils/schema";
+import type { Member } from "$lib/utils/schema";
 
 export function load({ locals }) {
   return {

--- a/src/routes/about/team/+page.server.ts
+++ b/src/routes/about/team/+page.server.ts
@@ -1,13 +1,12 @@
 import type { ContentWrapper } from "$lib/utils/api";
 import type { Member } from "src/lib/utils/schema";
-import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = ({ locals }) => {
+export function load({ locals }) {
   return {
     title: "The Team",
     members: getMembers(locals.contentWrapper),
   };
-};
+}
 
 async function getMembers(contentWrapper: ContentWrapper) {
   const members: Member[] = await contentWrapper.get("member", {

--- a/src/routes/about/team/+page.svelte
+++ b/src/routes/about/team/+page.svelte
@@ -2,9 +2,8 @@
   import Button from "$lib/components/Button.svelte";
   import Member from "$lib/components/Member.svelte";
   import Section from "$lib/components/Section.svelte";
-  import type { PageData } from "./$types";
 
-  export let data: PageData;
+  export let data;
 
   let showAllAlumni = false;
 

--- a/src/routes/about/work/+page.server.ts
+++ b/src/routes/about/work/+page.server.ts
@@ -1,6 +1,4 @@
-import type { PageServerLoad } from "./$types";
-
-export const load: PageServerLoad = ({ locals }) => {
+export function load({ locals }) {
   return {
     title: "How We Work",
     faqs: locals.contentWrapper.get("faq", {
@@ -8,4 +6,4 @@ export const load: PageServerLoad = ({ locals }) => {
       "fields.category": "Work",
     }),
   };
-};
+}

--- a/src/routes/about/work/+page.svelte
+++ b/src/routes/about/work/+page.svelte
@@ -5,9 +5,8 @@
   import Row from "$lib/components/Row.svelte";
   import Section from "$lib/components/Section.svelte";
   import Step from "$lib/components/Step.svelte";
-  import type { PageData } from "./$types";
 
-  export let data: PageData;
+  export let data;
 </script>
 
 <Section id="intro" padding="40px">

--- a/src/routes/apply/[page=apply_redirect]/+page.ts
+++ b/src/routes/apply/[page=apply_redirect]/+page.ts
@@ -1,7 +1,6 @@
 import { redirect } from "@sveltejs/kit";
-import type { PageLoad } from "./$types";
 
 // Redirect old links to apply/(nonprofits|sponors|students) to new page join/$1
-export const load: PageLoad = async ({ url }) => {
+export async function load({ url }) {
   throw redirect(301, url.pathname.replace("apply", "join"));
-};
+}

--- a/src/routes/images/people/[name].jpg/+server.ts
+++ b/src/routes/images/people/[name].jpg/+server.ts
@@ -1,6 +1,5 @@
 import { setImageHeight, titleCase, type Member } from "$lib/utils/schema";
 import { error } from "@sveltejs/kit";
-import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = async ({ params, fetch, url, locals }) => {
   const contentfulName = titleCase(params.name.replace("_", " "));

--- a/src/routes/images/people/[name].jpg/+server.ts
+++ b/src/routes/images/people/[name].jpg/+server.ts
@@ -1,7 +1,7 @@
 import { setImageHeight, titleCase, type Member } from "$lib/utils/schema";
 import { error } from "@sveltejs/kit";
 
-export const GET: RequestHandler = async ({ params, fetch, url, locals }) => {
+export async function GET({ params, fetch, url, locals }) {
   const contentfulName = titleCase(params.name.replace("_", " "));
 
   const members: Member[] = await locals.contentWrapper.get("member", {
@@ -21,4 +21,4 @@ export const GET: RequestHandler = async ({ params, fetch, url, locals }) => {
   }
 
   return fetch(imageURL);
-};
+}

--- a/src/routes/images/projects/[slug].jpg/+server.ts
+++ b/src/routes/images/projects/[slug].jpg/+server.ts
@@ -1,7 +1,7 @@
 import { setImageHeight, type Project } from "$lib/utils/schema";
 import { error } from "@sveltejs/kit";
 
-export const GET: RequestHandler = async ({ params, fetch, url, locals }) => {
+export async function GET({ params, fetch, url, locals }) {
   const projects: Project[] = await locals.contentWrapper.get("project", {
     "fields.slug": params.slug,
   });
@@ -19,4 +19,4 @@ export const GET: RequestHandler = async ({ params, fetch, url, locals }) => {
   }
 
   return fetch(imageURL);
-};
+}

--- a/src/routes/images/projects/[slug].jpg/+server.ts
+++ b/src/routes/images/projects/[slug].jpg/+server.ts
@@ -1,6 +1,5 @@
 import { setImageHeight, type Project } from "$lib/utils/schema";
 import { error } from "@sveltejs/kit";
-import type { RequestHandler } from "./$types";
 
 export const GET: RequestHandler = async ({ params, fetch, url, locals }) => {
   const projects: Project[] = await locals.contentWrapper.get("project", {

--- a/src/routes/join/nonprofits/+page.server.ts
+++ b/src/routes/join/nonprofits/+page.server.ts
@@ -1,8 +1,7 @@
 import { getTestimonialNonprofit } from "$lib/content/contentful";
 import type { FAQ, NonprofitStep } from "$lib/utils/schema";
-import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = ({ locals }) => {
+export function load({ locals }) {
   return {
     title: "Nonprofits",
     faqs: locals.contentWrapper.get("faq", {
@@ -14,4 +13,4 @@ export const load: PageServerLoad = ({ locals }) => {
     }) as Promise<NonprofitStep[]>,
     testimonialNonprofit: getTestimonialNonprofit(locals.contentWrapper),
   };
-};
+}

--- a/src/routes/join/nonprofits/+page.svelte
+++ b/src/routes/join/nonprofits/+page.svelte
@@ -6,9 +6,8 @@
   import Section from "$lib/components/Section.svelte";
   import Step from "$lib/components/Step.svelte";
   import Testimonial from "$lib/components/Testimonial.svelte";
-  import type { PageData } from "./$types";
 
-  export let data: PageData;
+  export let data;
 </script>
 
 <Section padding="60px">

--- a/src/routes/join/nonprofits/+page.svelte
+++ b/src/routes/join/nonprofits/+page.svelte
@@ -15,7 +15,7 @@
   <h2>Our Services</h2>
   <Row gap={58} topAligned>
     <div class="service">
-      <Icon icon="devices" />
+      <Icon icon="devices" color="var(--blue)" />
       <h3>Web & Mobile Applications</h3>
       <p>
         We provide our nonprofit partners with software solutions for their
@@ -24,7 +24,7 @@
       </p>
     </div>
     <div class="service">
-      <Icon icon="vector" />
+      <Icon icon="vector" color="var(--blue)" />
       <h3>Designs</h3>
       <p>
         Our designers create product designs tailored specifically to a
@@ -32,7 +32,7 @@
       </p>
     </div>
     <div class="service">
-      <Icon icon="conversation" />
+      <Icon icon="conversation" color="var(--blue)" />
       <h3>Iterative Feedback</h3>
       <p>
         Our project leads stay are consistently in touch with your nonprofit's

--- a/src/routes/join/sponsors/+page.server.ts
+++ b/src/routes/join/sponsors/+page.server.ts
@@ -1,8 +1,7 @@
 import { getTestimonialNonprofit } from "$lib/content/contentful";
 import type { FAQ } from "$lib/utils/schema";
-import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = ({ locals }) => {
+export function load({ locals }) {
   return {
     title: "Sponsors",
     faqs: locals.contentWrapper.get("faq", {
@@ -11,4 +10,4 @@ export const load: PageServerLoad = ({ locals }) => {
     }) as Promise<FAQ[]>,
     testimonialNonprofit: getTestimonialNonprofit(locals.contentWrapper),
   };
-};
+}

--- a/src/routes/join/sponsors/+page.svelte
+++ b/src/routes/join/sponsors/+page.svelte
@@ -9,9 +9,8 @@
   import Testimonial from "$lib/components/Testimonial.svelte";
   import { listFormatter } from "$lib/utils/format";
   import { Perk, type PerkType } from "$lib/utils/schema";
-  import type { PageData } from "./$types";
 
-  export let data: PageData;
+  export let data;
 
   interface SponsorTier {
     name: string;

--- a/src/routes/join/sponsors/+page.svelte
+++ b/src/routes/join/sponsors/+page.svelte
@@ -151,7 +151,9 @@
     <div class="perks">
       {#each Object.values(Perk) as perk}
         <article>
-          <div class="icon-container"><Icon icon={perk.icon} /></div>
+          <div class="icon-container">
+            <Icon icon={perk.icon} />
+          </div>
           <div>
             <h2>{perk.name}</h2>
             <h3>

--- a/src/routes/join/students/+page.server.ts
+++ b/src/routes/join/students/+page.server.ts
@@ -1,7 +1,6 @@
-import type { ApplicationStep, FAQ, Role } from "src/lib/utils/schema";
-import type { PageServerLoad } from "./$types";
+import type { ApplicationStep, FAQ, Role } from "$lib/utils/schema";
 
-export const load: PageServerLoad = ({ locals }) => {
+export function load({ locals }) {
   return {
     title: "Students",
     faqs: locals.contentWrapper.get("faq", {
@@ -16,4 +15,4 @@ export const load: PageServerLoad = ({ locals }) => {
       order: "fields.startDate,fields.name",
     }) as Promise<ApplicationStep[]>,
   };
-};
+}

--- a/src/routes/join/students/+page.svelte
+++ b/src/routes/join/students/+page.svelte
@@ -6,9 +6,8 @@
   import Row from "$lib/components/Row.svelte";
   import Section from "$lib/components/Section.svelte";
   import Step from "$lib/components/Step.svelte";
-  import type { PageData } from "./$types";
 
-  export let data: PageData;
+  export let data;
 
   const iconMap: Record<string, IconType> = {
     Calendar: "calendar",

--- a/src/routes/projects/+page.server.ts
+++ b/src/routes/projects/+page.server.ts
@@ -1,14 +1,13 @@
 import type { ContentWrapper } from "$lib/utils/api";
 import { generateProjectsInfo } from "$lib/utils/projects";
 import type { Project } from "$lib/utils/schema";
-import type { PageServerLoad } from "./$types";
 
-export const load: PageServerLoad = ({ locals }) => {
+export function load({ locals }) {
   return {
     title: "Projects",
     projectsInfo: getProjectsInfo(locals.contentWrapper),
   };
-};
+}
 
 async function getProjectsInfo(contentWrapper: ContentWrapper) {
   const projects: Project[] = await contentWrapper.get("project", {

--- a/src/routes/projects/+page.svelte
+++ b/src/routes/projects/+page.svelte
@@ -4,9 +4,8 @@
   import Section from "$lib/components/Section.svelte";
   import { semesterToId } from "$lib/utils/schema";
   import viewport from "$lib/utils/useViewportAction";
-  import type { PageData } from "./$types";
 
-  export let data: PageData;
+  export let data;
 
   let windowWidth: number | undefined;
 

--- a/src/routes/projects/[slug]/+page.server.ts
+++ b/src/routes/projects/[slug]/+page.server.ts
@@ -1,12 +1,11 @@
 import { error } from "@sveltejs/kit";
-import type { Project } from "src/lib/utils/schema";
-import type { PageServerLoad } from "./$types";
+import type { Project } from "$lib/utils/schema";
 
 // Prerender all projects found by SvelteKit crawler (displayed in projects page)
 // But include server-side JS to load any projects not found (preview projects)
 export const prerender = "auto";
 
-export const load: PageServerLoad = async ({ params, locals }) => {
+export async function load({ params, locals }) {
   const projects: Project[] = await locals.contentWrapper.get(
     "project",
     {
@@ -30,4 +29,4 @@ export const load: PageServerLoad = async ({ params, locals }) => {
     title: project.name,
     project,
   };
-};
+}

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -5,9 +5,8 @@
   import Testimonial from "$lib/components/Testimonial.svelte";
   import { pSBC } from "$lib/utils/color";
   import { setImageHeight } from "$lib/utils/schema";
-  import type { PageData } from "./$types";
 
-  export let data: PageData;
+  export let data;
 </script>
 
 <DoubleBanner


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Don't worry, haven't forgotten about #83. Recently @anyaparekh moved all project testimonials to the new testimonial content type, so a few more CSS changes and #83 will be good.

About this PR: Since a few devs are gonna take on some issues in this repo I thought it might be good to upgrade to the newest SvelteKit version, which makes writing page components and loading page data much simpler through the use of automatic type validation (no need to import or apply SvelteKit types). Type safety is still ensured via `svelte-check` as well as within VSCode.

EDIT: This PR also now removes the @svicons/boxicons-* dependencies and instead uses @iconify/svelte. @svicons no longer exists, and @iconify seems to be a reliable replacement.

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
