### PR TITLE
Add Learn More button to Nonprofit in Project

### DIFF
--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -50,7 +50,8 @@
   <Button
     href={data.project.nonprofitUrl}
     type="primary-custom"
-    textColor={data.project.accentColor}
+    textColor="white"
+    backgroundColor={data.project.accentColor}
     size="small">Learn More &nearr;</Button
   >
 </Section>

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import Button from "$lib/components/Button.svelte";
   import DoubleBanner from "$lib/components/DoubleBanner.svelte";
   import ProjectMember from "$lib/components/projects/ProjectMember.svelte";
   import Section from "$lib/components/Section.svelte";
@@ -46,8 +47,13 @@
 >
   <h2>Our Partner</h2>
   <p>{data.project.nonprofitDescription}</p>
+  <Button
+    href={data.project.nonprofitUrl}
+    type="secondary-custom"
+    textColor={data.project.accentColor}
+    size="small">Learn More &nearr;</Button
+  >
 </Section>
-
 <Section
   id="project-description"
   longForm

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -49,11 +49,12 @@
   <p>{data.project.nonprofitDescription}</p>
   <Button
     href={data.project.nonprofitUrl}
-    type="secondary-custom"
+    type="primary-custom"
     textColor={data.project.accentColor}
     size="small">Learn More &nearr;</Button
   >
 </Section>
+
 <Section
   id="project-description"
   longForm


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status: :rocket: Ready

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

Adds a "Learn More" button that leads to the nonprofit's website in each H4I project's page
<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #85 

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<img width="1104" alt="Screen Shot 2023-03-23 at 1 24 17 PM" src="https://user-images.githubusercontent.com/89177504/227311482-379e1251-7234-488a-adee-6a9ed331339e.png">


<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
