### PR TITLE
Make wide images full bleed on mobile

### DIFF
--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -159,6 +159,18 @@
     border-radius: 4px;
   }
 
+  @media (max-width: 650px) {
+    :global(#project-description img) {
+      max-width: 100%;
+      border-radius: 0;
+    }
+
+    :global(#project-description .long-form-embed) {
+      width: calc(100% + 20vw);
+      margin-left: -10vw;
+    }
+  }
+
   :global(#project-description h1) {
     font-size: 1.6rem;
   }


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

<!--
:rocket: Ready
:construction: In development
:no_entry_sign: Do not merge
-->

## Description

<!--
A few sentences describing the overall goals of the pull request's commits.
-->

Fixes #<number>

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
