### PR TITLE
Add borders to project images

### DIFF
--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -157,6 +157,7 @@
     object-fit: contain;
     max-height: 600px;
     border-radius: 4px;
+    border: 1px solid var(--accent-color);
   }
 
   :global(#project-description h1) {


### PR DESCRIPTION
<!--
Template sourced from https://github.com/hack4impact-uiuc/life-after-hate
Shoutout to the wonderful LAH team!
-->

## Status:

:rocket: Ready

## Description

This is certainly not the best solution to preventing many white background project page images from blending into the page, but it's a temporary work around that mostly improves images of cause and has less of an effect on other images.

## Todos

<!--
- [ ] Tests
- [ ] Documentation
-->

## Screenshots

<!--
Mac OS Screenshots: ctrl + shift + cmd + 3 (entire screen) or 4 (selection of screen), then paste in editor
Mac OS GIFs: Try using Kap
Linux/Windows: Ctrl + Alt + PrintScreen (of a window) or Ctrl + Shift + PrintScreen (selection of screen), then paste in editor
-->
